### PR TITLE
Fix concurrency issues and other optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func main() {
         DistributionPort: 40000, // set this (typically 40000) to send distributions
         TracingPort : 50000,     // set this to send tracing spans
 
-        FlushIntervalSeconds: 10 // flush the buffer periodically, defaults to 5 seconds.
+        FlushIntervalSeconds: 10, // flush the buffer periodically, defaults to 5 seconds.
     }
 
     sender, err := wavefront.NewProxySender(proxyCfg)
@@ -93,7 +93,7 @@ Use the `Sender` interface for sending data to Wavefront.
 // Wavefront metrics data format
 // <metricName> <metricValue> [<timestamp>] source=<source> [pointTags]
 // Example: "new-york.power.usage 42422 1533529977 source=localhost datacenter=dc1"
-sender.SendMetric("new-york.power.usage", 42422.0, 0, "go_test", map[string]string{"env", "test"})
+sender.SendMetric("new-york.power.usage", 42422.0, 0, "go_test", map[string]string{"env" : "test"})
 
 // Wavefront delta counter format
 // <metricName> <metricValue> source=<source> [pointTags]

--- a/application/heartbeater.go
+++ b/application/heartbeater.go
@@ -19,7 +19,7 @@ type heartbeater struct {
 	components  []string
 
 	ticker *time.Ticker
-	stop   chan bool
+	stop   chan struct{}
 }
 
 // StartHeartbeatService will create and start a new HeartbeatService
@@ -30,7 +30,7 @@ func StartHeartbeatService(sender senders.Sender, application Tags, source strin
 		source:      source,
 		components:  components,
 		ticker:      time.NewTicker(5 * time.Minute),
-		stop:        make(chan bool, 1),
+		stop:        make(chan struct{}),
 	}
 
 	go func() {
@@ -49,7 +49,8 @@ func StartHeartbeatService(sender senders.Sender, application Tags, source strin
 }
 
 func (hb *heartbeater) Close() {
-	hb.stop <- true
+	hb.ticker.Stop()
+	hb.stop <- struct{}{} // block until goroutine exits
 }
 
 func (hb *heartbeater) beat() {

--- a/senders/direct_test.go
+++ b/senders/direct_test.go
@@ -1,0 +1,92 @@
+package senders
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/wavefronthq/wavefront-sdk-go/histogram"
+)
+
+var direct Sender
+var server http.Server
+
+const (
+	testPort = "8080"
+)
+
+func init() {
+	server = http.Server{
+		Addr: "localhost:" + testPort,
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println("\n=========", r.URL, r.Method, r.Header.Get("Authorization"))
+		gr, _ := gzip.NewReader(r.Body)
+		msg, _ := ioutil.ReadAll(gr)
+		fmt.Println(string(msg))
+		w.WriteHeader(http.StatusOK)
+	})
+	go func() {
+		server.ListenAndServe()
+	}()
+}
+
+func TestDirectSends(t *testing.T) {
+	directCfg := &DirectConfiguration{
+		Server:               "http://localhost:" + testPort,
+		Token:                "DUMMY_TOKEN",
+		BatchSize:            10000,
+		MaxBufferSize:        50000,
+		FlushIntervalSeconds: 1,
+	}
+
+	var err error
+	if direct, err = NewDirectSender(directCfg); err != nil {
+		t.Error("Failed Creating Sender", err)
+	}
+
+	if err = direct.SendMetric("new-york.power.usage", 42422.0, 0, "go_test", map[string]string{"env": "test"}); err != nil {
+		t.Error("Failed SendMetric", err)
+	}
+	if err = direct.SendDeltaCounter("lambda.thumbnail.generate", 10.0, "thumbnail_service", map[string]string{"format": "jpeg"}); err != nil {
+		t.Error("Failed SendDeltaCounter", err)
+	}
+
+	centroids := []histogram.Centroid{
+		{Value: 30.0, Count: 20},
+		{Value: 5.1, Count: 10},
+	}
+
+	hgs := map[histogram.Granularity]bool{
+		histogram.MINUTE: true,
+		histogram.HOUR:   true,
+		histogram.DAY:    true,
+	}
+
+	if err = direct.SendDistribution("request.latency", centroids, hgs, 0, "appServer1", map[string]string{"region": "us-west"}); err != nil {
+		t.Error("Failed SendDistribution", err)
+	}
+
+	if err = direct.SendSpan("getAllUsers", 0, 343500, "localhost",
+		"7b3bf470-9456-11e8-9eb6-529269fb1459", "0313bafe-9457-11e8-9eb6-529269fb1459",
+		[]string{"2f64e538-9457-11e8-9eb6-529269fb1459"}, nil,
+		[]SpanTag{
+			{Key: "application", Value: "Wavefront"},
+			{Key: "http.method", Value: "GET"},
+		},
+		nil); err != nil {
+		t.Error("Failed SendSpan", err)
+	}
+
+	direct.Flush()
+	direct.Close()
+	if direct.GetFailureCount() > 0 {
+		t.Error("FailureCount =", direct.GetFailureCount())
+	}
+
+	server.Shutdown(context.Background())
+}

--- a/senders/formatter.go
+++ b/senders/formatter.go
@@ -2,7 +2,7 @@ package senders
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"strconv"
 
 	"github.com/wavefronthq/wavefront-sdk-go/histogram"
@@ -14,7 +14,7 @@ import (
 func MetricLine(name string, value float64, ts int64, source string, tags map[string]string, defaultSource string) (string, error) {
 
 	if name == "" {
-		return "", fmt.Errorf("empty metric name")
+		return "", errors.New("empty metric name")
 	}
 
 	if source == "" {
@@ -36,7 +36,7 @@ func MetricLine(name string, value float64, ts int64, source string, tags map[st
 
 	for k, v := range tags {
 		if v == "" {
-			return "", fmt.Errorf("metric point tag value cannot be blank")
+			return "", errors.New("metric point tag value cannot be blank")
 		}
 		sb.WriteString(" ")
 		sb.WriteString(strconv.Quote(k))
@@ -53,15 +53,15 @@ func MetricLine(name string, value float64, ts int64, source string, tags map[st
 func HistoLine(name string, centroids []histogram.Centroid, hgs map[histogram.Granularity]bool, ts int64, source string, tags map[string]string, defaultSource string) (string, error) {
 
 	if name == "" {
-		return "", fmt.Errorf("empty distribution name")
+		return "", errors.New("empty distribution name")
 	}
 
 	if len(centroids) == 0 {
-		return "", fmt.Errorf("distribution should have at least one centroid")
+		return "", errors.New("distribution should have at least one centroid")
 	}
 
 	if len(hgs) == 0 {
-		return "", fmt.Errorf("histogram granularities cannot be empty")
+		return "", errors.New("histogram granularities cannot be empty")
 	}
 
 	if source == "" {
@@ -87,7 +87,7 @@ func HistoLine(name string, centroids []histogram.Centroid, hgs map[histogram.Gr
 
 	for k, v := range tags {
 		if v == "" {
-			return "", fmt.Errorf("histogram tag value cannot be blank")
+			return "", errors.New("histogram tag value cannot be blank")
 		}
 		sb.WriteString(" ")
 		sb.WriteString(strconv.Quote(k))
@@ -113,14 +113,19 @@ func HistoLine(name string, centroids []histogram.Centroid, hgs map[histogram.Gr
 func SpanLine(name string, startMillis, durationMillis int64, source, traceId, spanId string, parents, followsFrom []string, tags []SpanTag, spanLogs []SpanLog, defaultSource string) (string, error) {
 
 	if name == "" {
-		return "", fmt.Errorf("empty span name")
+		return "", errors.New("empty span name")
 	}
 
 	if source == "" {
 		source = defaultSource
 	}
 
-	//TODO: verify if strings are uuid?
+	if !isUUIDFormat(traceId) {
+		return "", errors.New("traceId is not in UUID format")
+	}
+	if !isUUIDFormat(spanId) {
+		return "", errors.New("spanId is not in UUID format")
+	}
 
 	sb := bytes.Buffer{}
 	sb.WriteString(strconv.Quote(name))
@@ -143,7 +148,7 @@ func SpanLine(name string, startMillis, durationMillis int64, source, traceId, s
 
 	for _, tag := range tags {
 		if tag.Key == "" || tag.Value == "" {
-			return "", fmt.Errorf("span tag key/value cannot be blank")
+			return "", errors.New("span tag key/value cannot be blank")
 		}
 		sb.WriteString(" ")
 		sb.WriteString(strconv.Quote(tag.Key))
@@ -157,4 +162,22 @@ func SpanLine(name string, startMillis, durationMillis int64, source, traceId, s
 	sb.WriteString("\n")
 
 	return sb.String(), nil
+}
+
+func isUUIDFormat(str string) bool {
+	l := len(str)
+	if l != 36 {
+		return false
+	}
+	for i := 0; i < l; i++ {
+		c := str[i]
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			if c != '-' {
+				return false
+			}
+		} else if !(('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')) {
+			return false
+		}
+	}
+	return true
 }

--- a/senders/formatter_test.go
+++ b/senders/formatter_test.go
@@ -96,3 +96,31 @@ func makeCentroids() []histogram.Centroid {
 	}
 	return centroids
 }
+
+func TestVerifyUUID(tt *testing.T) {
+	tt.Run("Good UUID 1", func(t *testing.T) {
+		if isUUIDFormat("00112233-4455-6677-8899-aabbccddeeff") == false {
+			t.Fail()
+		}
+	})
+	tt.Run("Good UUID 2", func(t *testing.T) {
+		if isUUIDFormat("AABBCCDD-EEFF-0011-2233-445566778899") == false {
+			t.Fail()
+		}
+	})
+	tt.Run("Bad UUID 1", func(t *testing.T) {
+		if isUUIDFormat("00112233-4455-6677-8899-aabbccddee") == true {
+			t.Fail()
+		}
+	})
+	tt.Run("Bad UUID 2", func(t *testing.T) {
+		if isUUIDFormat("00112233-445506677-8899-aabbccddeeff") == true {
+			t.Fail()
+		}
+	})
+	tt.Run("Bad UUID 3", func(t *testing.T) {
+		if isUUIDFormat("00112233-44SS-6677-8899-aabbccddeeff") == true {
+			t.Fail()
+		}
+	})
+}

--- a/senders/proxy.go
+++ b/senders/proxy.go
@@ -50,10 +50,10 @@ func NewProxySender(cfg *ProxyConfiguration) (Sender, error) {
 	return sender, nil
 }
 
-func makeConnHandler(host string, port, interval int) internal.ConnectionHandler {
+func makeConnHandler(host string, port, flushIntervalSeconds int) internal.ConnectionHandler {
 	addr := fmt.Sprintf("%s:%d", host, port)
-	ticker := time.NewTicker(time.Second * time.Duration(interval))
-	return internal.NewProxyConnectionHandler(addr, ticker)
+	flushInterval := time.Second * time.Duration(flushIntervalSeconds)
+	return internal.NewProxyConnectionHandler(addr, flushInterval)
 }
 
 func (sender *proxySender) Start() {
@@ -73,11 +73,9 @@ func (sender *proxySender) SendMetric(name string, value float64, ts int64, sour
 		return fmt.Errorf("proxy metrics port not provided, cannot send metric data")
 	}
 
-	if !sender.metricHandler.Connected() {
-		err := sender.metricHandler.Connect()
-		if err != nil {
-			return err
-		}
+	err := sender.metricHandler.Connect()
+	if err != nil {
+		return err
 	}
 
 	line, err := MetricLine(name, value, ts, source, tags, sender.defaultSource)
@@ -103,11 +101,9 @@ func (sender *proxySender) SendDistribution(name string, centroids []histogram.C
 		return fmt.Errorf("proxy distribution port not provided, cannot send distribution data")
 	}
 
-	if !sender.histoHandler.Connected() {
-		err := sender.histoHandler.Connect()
-		if err != nil {
-			return err
-		}
+	err := sender.histoHandler.Connect()
+	if err != nil {
+		return err
 	}
 
 	line, err := HistoLine(name, centroids, hgs, ts, source, tags, sender.defaultSource)
@@ -123,11 +119,9 @@ func (sender *proxySender) SendSpan(name string, startMillis, durationMillis int
 		return fmt.Errorf("proxy tracing port not provided, cannot send span data")
 	}
 
-	if !sender.spanHandler.Connected() {
-		err := sender.spanHandler.Connect()
-		if err != nil {
-			return err
-		}
+	err := sender.spanHandler.Connect()
+	if err != nil {
+		return err
 	}
 
 	line, err := SpanLine(name, startMillis, durationMillis, source, traceId, spanId, parents, followsFrom, tags, spanLogs, sender.defaultSource)

--- a/senders/proxy_test.go
+++ b/senders/proxy_test.go
@@ -1,0 +1,84 @@
+package senders
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/wavefronthq/wavefront-sdk-go/histogram"
+)
+
+var proxy Sender
+
+func netcat(addr string, keepopen bool) {
+	laddr, _ := net.ResolveTCPAddr("tcp", addr)
+	lis, _ := net.ListenTCP("tcp", laddr)
+	fmt.Println("Listening @", addr)
+	for loop := true; loop; loop = keepopen {
+		conn, _ := lis.Accept()
+		io.Copy(os.Stdout, conn)
+	}
+	lis.Close()
+}
+
+func init() {
+	go netcat("localhost:30000", false)
+	go netcat("localhost:40000", false)
+	go netcat("localhost:50000", false)
+}
+
+func TestProxySends(t *testing.T) {
+	proxyCfg := &ProxyConfiguration{
+		Host:                 "localhost",
+		MetricsPort:          30000,
+		DistributionPort:     40000,
+		TracingPort:          50000,
+		FlushIntervalSeconds: 10,
+	}
+
+	var err error
+	if proxy, err = NewProxySender(proxyCfg); err != nil {
+		t.Error("Failed Creating Sender", err)
+	}
+
+	if err = proxy.SendMetric("new-york.power.usage", 42422.0, 0, "go_test", map[string]string{"env": "test"}); err != nil {
+		t.Error("Failed SendMetric", err)
+	}
+	if err = proxy.SendDeltaCounter("lambda.thumbnail.generate", 10.0, "thumbnail_service", map[string]string{"format": "jpeg"}); err != nil {
+		t.Error("Failed SendDeltaCounter", err)
+	}
+
+	centroids := []histogram.Centroid{
+		{Value: 30.0, Count: 20},
+		{Value: 5.1, Count: 10},
+	}
+
+	hgs := map[histogram.Granularity]bool{
+		histogram.MINUTE: true,
+		histogram.HOUR:   true,
+		histogram.DAY:    true,
+	}
+
+	if err = proxy.SendDistribution("request.latency", centroids, hgs, 0, "appServer1", map[string]string{"region": "us-west"}); err != nil {
+		t.Error("Failed SendDistribution", err)
+	}
+
+	if err = proxy.SendSpan("getAllUsers", 0, 343500, "localhost",
+		"7b3bf470-9456-11e8-9eb6-529269fb1459", "0313bafe-9457-11e8-9eb6-529269fb1459",
+		[]string{"2f64e538-9457-11e8-9eb6-529269fb1459"}, nil,
+		[]SpanTag{
+			{Key: "application", Value: "Wavefront"},
+			{Key: "http.method", Value: "GET"},
+		},
+		nil); err != nil {
+		t.Error("Failed SendSpan", err)
+	}
+
+	proxy.Flush()
+	proxy.Close()
+	if proxy.GetFailureCount() > 0 {
+		t.Error("FailureCount =", proxy.GetFailureCount())
+	}
+}


### PR DESCRIPTION
**Fixes & Changes**

- [x] Connected-Connect race in Proxy Sender
- [x] LineHandler Flush race/panic due to bufLen
- [x] Flush in right order: ProxyConnHandler, LineHandler
- [x] FlushAll added to LineHandler to flush all lines on Close()
- [x] resetConnection close (Finalizer will close it but Conn lingers until GC'd)
- [x] HistoLine preprocessing
- [x] Heartbeater Ticker leak
- [x] Unnecessary NewBufferString 
- [x] Signal channels: ProxyConnHandler, LineHandler, Heartbeater
- [x]  Ticker refactoring in handlers
- [x]  Readme edits
- [x]  Initial testing framework for senders (partially automated)
