### PR TITLE
Update sender.md

### DIFF
--- a/docs/sender.md
+++ b/docs/sender.md
@@ -103,7 +103,7 @@ func main() {
         DistributionPort: 2878,
         
         // Set a proxy port to send trace data to. Recommended: 30000
-        TracingPort : 50000,
+        TracingPort : 30000,
         
         // Optional: Set a nondefault interval (in seconds) for flushing data from the sender to the proxy. Default: 5 seconds
         FlushIntervalSeconds: 10 

--- a/docs/sender.md
+++ b/docs/sender.md
@@ -99,8 +99,8 @@ func main() {
         // Set the proxy port to send metrics to. Default: 2878
         MetricsPort : 2878, 
         
-        // Set a proxy port to send histograms to.  Recommended: 40000
-        DistributionPort: 40000,
+        // Set a proxy port to send histograms to.  Recommended: 2878
+        DistributionPort: 2878,
         
         // Set a proxy port to send trace data to. Recommended: 30000
         TracingPort : 50000,


### PR DESCRIPTION
Recommended port for histograms is now 2878, not 40000.