### PR TITLE
performance/memory improvements

### DIFF
--- a/senders/configs.go
+++ b/senders/configs.go
@@ -18,7 +18,7 @@ type DirectConfiguration struct {
 	// max batch of data sent per flush interval. defaults to 10,000. recommended not to exceed 40,000.
 	BatchSize int
 
-	// size of internal buffer beyond which received data is dropped.
+	// size of internal buffers beyond which received data is dropped.
 	// helps with handling brief increases in data and buffering on errors.
 	// separate buffers are maintained per data type (metrics, spans and distributions)
 	// buffers are not pre-allocated to max size and vary based on actual usage.

--- a/senders/formatter_test.go
+++ b/senders/formatter_test.go
@@ -6,6 +6,22 @@ import (
 	"github.com/wavefronthq/wavefront-sdk-go/histogram"
 )
 
+var line string
+
+func BenchmarkMetricLine(b *testing.B) {
+	name := "foo.metric"
+	value := 1.2
+	ts := int64(1533529977)
+	src := "test_source"
+	tags := map[string]string{"env": "test"}
+
+	var r string
+	for n := 0; n < b.N; n++ {
+		r, _ = MetricLine(name, value, ts, src, tags, "")
+	}
+	line = r
+}
+
 func TestMetricLine(t *testing.T) {
 	line, err := MetricLine("foo.metric", 1.2, 1533529977, "test_source",
 		map[string]string{"env": "test"}, "")
@@ -16,6 +32,21 @@ func TestMetricLine(t *testing.T) {
 		map[string]string{"env": "test"}, "default")
 	expected = "\"foo.metric\" 1.2 1533529977 source=\"default\" \"env\"=\"test\"\n"
 	assertEquals(expected, line, err, t)
+}
+
+func BenchmarkHistoLine(b *testing.B) {
+	name := "request.latency"
+	centroids := makeCentroids()
+	hgs := map[histogram.Granularity]bool{histogram.MINUTE: true}
+	ts := int64(1533529977)
+	src := "test_source"
+	tags := map[string]string{"env": "test"}
+
+	var r string
+	for n := 0; n < b.N; n++ {
+		r, _ = HistoLine(name, centroids, hgs, ts, src, tags, "")
+	}
+	line = r
 }
 
 func TestHistoLine(t *testing.T) {
@@ -48,6 +79,20 @@ func TestHistoLine(t *testing.T) {
 	if len(line) != len(expected) {
 		t.Errorf("lines don't match. expected: %s, actual: %s", expected, line)
 	}
+}
+
+func BenchmarkSpanLine(b *testing.B) {
+	name := "order.shirts"
+	start := int64(1533531013)
+	dur := int64(343500)
+	src := "test_source"
+	traceId := "7b3bf470-9456-11e8-9eb6-529269fb1459"
+
+	var r string
+	for n := 0; n < b.N; n++ {
+		r, _ = SpanLine(name, start, dur, src, traceId, traceId, []string{traceId}, nil, nil, nil, "")
+	}
+	line = r
 }
 
 func TestSpanLine(t *testing.T) {

--- a/senders/pool.go
+++ b/senders/pool.go
@@ -1,0 +1,27 @@
+package senders
+
+import (
+	"bytes"
+	"sync"
+)
+
+var buffers *sync.Pool
+
+func init() {
+	buffers = &sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+}
+
+// GetBuffer fetches a buffers from the pool
+func GetBuffer() *bytes.Buffer {
+	return buffers.Get().(*bytes.Buffer)
+}
+
+// PutBuffer returns a buffers to the pool
+func PutBuffer(buf *bytes.Buffer) {
+	buf.Reset()
+	buffers.Put(buf)
+}

--- a/senders/proxy_test.go
+++ b/senders/proxy_test.go
@@ -1,7 +1,6 @@
 package senders
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"os"
@@ -15,7 +14,6 @@ var proxy Sender
 func netcat(addr string, keepopen bool) {
 	laddr, _ := net.ResolveTCPAddr("tcp", addr)
 	lis, _ := net.ListenTCP("tcp", laddr)
-	fmt.Println("Listening @", addr)
 	for loop := true; loop; loop = keepopen {
 		conn, _ := lis.Accept()
 		io.Copy(os.Stdout, conn)


### PR DESCRIPTION
Improves memory use/allocations when building point lines.

Metrics:
```
benchmark                 old ns/op     new ns/op     delta
BenchmarkMetricLine-8     887           925           +4.28%

benchmark                 old allocs     new allocs     delta
BenchmarkMetricLine-8     10             9              -10.00%

benchmark                 old bytes     new bytes     delta
BenchmarkMetricLine-8     232           168           -27.59%
```

Histograms:
```
benchmark                old ns/op     new ns/op     delta
BenchmarkHistoLine-8     1499          1403          -6.40%

benchmark                old allocs     new allocs     delta
BenchmarkHistoLine-8     15             13             -13.33%

benchmark                old bytes     new bytes     delta
BenchmarkHistoLine-8     728           520           -28.57%
```

Spans:
```
benchmark               old ns/op     new ns/op     delta
BenchmarkSpanLine-8     955           768           -19.58%

benchmark               old allocs     new allocs     delta
BenchmarkSpanLine-8     8              5              -37.50%

benchmark               old bytes     new bytes     delta
BenchmarkSpanLine-8     880           256           -70.91%
```