### PR TITLE
Align LineHandler struct fields to allow atomic access

### DIFF
--- a/internal/lines.go
+++ b/internal/lines.go
@@ -22,7 +22,7 @@ const (
 type LineHandler struct {
 	failures  int64
 	throttled int64
-	
+
 	Reporter      Reporter
 	BatchSize     int
 	MaxBufferSize int

--- a/internal/lines.go
+++ b/internal/lines.go
@@ -20,6 +20,9 @@ const (
 )
 
 type LineHandler struct {
+	failures  int64
+	throttled int64
+	
 	Reporter      Reporter
 	BatchSize     int
 	MaxBufferSize int
@@ -31,9 +34,6 @@ type LineHandler struct {
 
 	mtx                sync.Mutex
 	lockOnErrThrottled bool
-
-	failures  int64
-	throttled int64
 
 	buffer chan string
 	done   chan struct{}


### PR DESCRIPTION
This is the proposed fix for #51. By moving the `failures` and `throttled` fields to the top of the struct we can ensure they are 64-bit aligned.