### PR TITLE
Allow for tagging internal SDK metrics

### DIFF
--- a/internal/registry.go
+++ b/internal/registry.go
@@ -38,7 +38,7 @@ func SetSource(source string) RegistryOption {
 
 func SetInterval(interval int) RegistryOption {
 	return func(registry *MetricRegistry) {
-		registry.reportTicker = time.NewTicker(time.Second * time.Duration(interval))
+		registry.reportTicker = time.NewTicker(time.Millisecond * time.Duration(interval))
 	}
 }
 

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -19,7 +19,7 @@ type internalSender interface {
 type MetricRegistry struct {
 	source       string
 	prefix       string
-	Tags         map[string]string
+	tags         map[string]string
 	reportTicker *time.Ticker
 	sender       internalSender
 	done         chan struct{}
@@ -44,16 +44,16 @@ func SetInterval(interval int) RegistryOption {
 
 func SetTags(tags map[string]string) RegistryOption {
 	return func(registry *MetricRegistry) {
-		registry.Tags = tags
+		registry.tags = tags
 	}
 }
 
 func SetTag(key, value string) RegistryOption {
 	return func(registry *MetricRegistry) {
-		if registry.Tags == nil {
-			registry.Tags = make(map[string]string)
+		if registry.tags == nil {
+			registry.tags = make(map[string]string)
 		}
-		registry.Tags[key] = value
+		registry.tags[key] = value
 	}
 }
 
@@ -120,14 +120,14 @@ func (registry *MetricRegistry) report() {
 		switch metric.(type) {
 		case *DeltaCounter:
 			deltaCount := metric.(*DeltaCounter).count()
-			registry.sender.SendDeltaCounter(registry.prefix+"."+k, float64(deltaCount), "", registry.Tags)
+			registry.sender.SendDeltaCounter(registry.prefix+"."+k, float64(deltaCount), "", registry.tags)
 			metric.(*DeltaCounter).dec(deltaCount)
 		case *MetricCounter:
-			registry.sender.SendMetric(registry.prefix+"."+k, float64(metric.(*MetricCounter).count()), 0, "", registry.Tags)
+			registry.sender.SendMetric(registry.prefix+"."+k, float64(metric.(*MetricCounter).count()), 0, "", registry.tags)
 		case *FunctionalGauge:
-			registry.sender.SendMetric(registry.prefix+"."+k, float64(metric.(*FunctionalGauge).instantValue()), 0, "", registry.Tags)
+			registry.sender.SendMetric(registry.prefix+"."+k, float64(metric.(*FunctionalGauge).instantValue()), 0, "", registry.tags)
 		case *FunctionalGaugeFloat64:
-			registry.sender.SendMetric(registry.prefix+"."+k, metric.(*FunctionalGaugeFloat64).instantValue(), 0, "", registry.Tags)
+			registry.sender.SendMetric(registry.prefix+"."+k, metric.(*FunctionalGaugeFloat64).instantValue(), 0, "", registry.tags)
 		}
 	}
 }

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -19,7 +19,7 @@ type internalSender interface {
 type MetricRegistry struct {
 	source       string
 	prefix       string
-	tags         map[string]string
+	Tags         map[string]string
 	reportTicker *time.Ticker
 	sender       internalSender
 	done         chan struct{}
@@ -44,16 +44,16 @@ func SetInterval(interval int) RegistryOption {
 
 func SetTags(tags map[string]string) RegistryOption {
 	return func(registry *MetricRegistry) {
-		registry.tags = tags
+		registry.Tags = tags
 	}
 }
 
 func SetTag(key, value string) RegistryOption {
 	return func(registry *MetricRegistry) {
-		if registry.tags == nil {
-			registry.tags = make(map[string]string)
+		if registry.Tags == nil {
+			registry.Tags = make(map[string]string)
 		}
-		registry.tags[key] = value
+		registry.Tags[key] = value
 	}
 }
 
@@ -120,14 +120,14 @@ func (registry *MetricRegistry) report() {
 		switch metric.(type) {
 		case *DeltaCounter:
 			deltaCount := metric.(*DeltaCounter).count()
-			registry.sender.SendDeltaCounter(registry.prefix+"."+k, float64(deltaCount), "", registry.tags)
+			registry.sender.SendDeltaCounter(registry.prefix+"."+k, float64(deltaCount), "", registry.Tags)
 			metric.(*DeltaCounter).dec(deltaCount)
 		case *MetricCounter:
-			registry.sender.SendMetric(registry.prefix+"."+k, float64(metric.(*MetricCounter).count()), 0, "", registry.tags)
+			registry.sender.SendMetric(registry.prefix+"."+k, float64(metric.(*MetricCounter).count()), 0, "", registry.Tags)
 		case *FunctionalGauge:
-			registry.sender.SendMetric(registry.prefix+"."+k, float64(metric.(*FunctionalGauge).instantValue()), 0, "", registry.tags)
+			registry.sender.SendMetric(registry.prefix+"."+k, float64(metric.(*FunctionalGauge).instantValue()), 0, "", registry.Tags)
 		case *FunctionalGaugeFloat64:
-			registry.sender.SendMetric(registry.prefix+"."+k, metric.(*FunctionalGaugeFloat64).instantValue(), 0, "", registry.tags)
+			registry.sender.SendMetric(registry.prefix+"."+k, metric.(*FunctionalGaugeFloat64).instantValue(), 0, "", registry.Tags)
 		}
 	}
 }

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -36,9 +36,9 @@ func SetSource(source string) RegistryOption {
 	}
 }
 
-func SetInterval(interval int) RegistryOption {
+func SetInterval(interval time.Duration) RegistryOption {
 	return func(registry *MetricRegistry) {
-		registry.reportTicker = time.NewTicker(time.Millisecond * time.Duration(interval))
+		registry.reportTicker = time.NewTicker(interval)
 	}
 }
 

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -43,6 +43,7 @@ type configuration struct {
 	// together with batch size controls the max theoretical throughput of the sender.
 	FlushIntervalSeconds int
 	SDKMetricsTags       map[string]string
+	ReportTicker         int
 }
 
 // NewSender creates Wavefront client
@@ -124,6 +125,10 @@ func (sender *wavefrontSender) initializeInternalMetrics(cfg *configuration) {
 		setters = append(setters, internal.SetTag(key, value))
 	}
 
+	if cfg.ReportTicker != 0 {
+		setters = append(setters, internal.SetInterval(cfg.ReportTicker))
+	}
+
 	sender.internalRegistry = internal.NewMetricRegistry(
 		sender,
 		setters...,
@@ -195,5 +200,11 @@ func SDKMetricsTags(tags map[string]string) Option {
 			cfg.SDKMetricsTags = tags
 		}
 
+	}
+}
+
+func ReportTicker(reportTicker int) Option {
+	return func(cfg *configuration) {
+		cfg.ReportTicker = reportTicker
 	}
 }

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/wavefronthq/wavefront-sdk-go/internal"
 )
@@ -43,7 +44,7 @@ type configuration struct {
 	// together with batch size controls the max theoretical throughput of the sender.
 	FlushIntervalSeconds int
 	SDKMetricsTags       map[string]string
-	ReportTicker         int
+	ReportTicker         time.Duration
 }
 
 // NewSender creates Wavefront client
@@ -203,7 +204,7 @@ func SDKMetricsTags(tags map[string]string) Option {
 	}
 }
 
-func ReportTicker(reportTicker int) Option {
+func ReportTicker(reportTicker time.Duration) Option {
 	return func(cfg *configuration) {
 		cfg.ReportTicker = reportTicker
 	}

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -187,6 +187,13 @@ func TracesPort(port int) Option {
 // SDKMetricsTags sets internal SDK metrics.
 func SDKMetricsTags(tags map[string]string) Option {
 	return func(cfg *configuration) {
-		cfg.SDKMetricsTags = tags
+		if cfg.SDKMetricsTags != nil {
+			for key, value := range tags {
+				cfg.SDKMetricsTags[key] = value
+			}
+		} else {
+			cfg.SDKMetricsTags = tags
+		}
+
 	}
 }

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -2,13 +2,11 @@ package senders
 
 import (
 	"fmt"
+	"github.com/wavefronthq/wavefront-sdk-go/internal"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
-	"time"
-
-	"github.com/wavefronthq/wavefront-sdk-go/internal"
 )
 
 const (
@@ -44,7 +42,6 @@ type configuration struct {
 	// together with batch size controls the max theoretical throughput of the sender.
 	FlushIntervalSeconds int
 	SDKMetricsTags       map[string]string
-	ReportTicker         time.Duration
 }
 
 // NewSender creates Wavefront client
@@ -126,10 +123,6 @@ func (sender *wavefrontSender) initializeInternalMetrics(cfg *configuration) {
 		setters = append(setters, internal.SetTag(key, value))
 	}
 
-	if cfg.ReportTicker != 0 {
-		setters = append(setters, internal.SetInterval(cfg.ReportTicker))
-	}
-
 	sender.internalRegistry = internal.NewMetricRegistry(
 		sender,
 		setters...,
@@ -201,11 +194,5 @@ func SDKMetricsTags(tags map[string]string) Option {
 			cfg.SDKMetricsTags = tags
 		}
 
-	}
-}
-
-func ReportTicker(reportTicker time.Duration) Option {
-	return func(cfg *configuration) {
-		cfg.ReportTicker = reportTicker
 	}
 }

--- a/senders/client_factory_test.go
+++ b/senders/client_factory_test.go
@@ -86,8 +86,9 @@ func TestTracesPort(t *testing.T) {
 }
 
 func TestSDKMetricsTags(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost", senders.SDKMetricsTags(map[string]string{"foo": "bar"}))
+	cfg, err := senders.CreateConfig("https://localhost", senders.SDKMetricsTags(map[string]string{"foo": "bar"}), senders.SDKMetricsTags(map[string]string{"foo1": "bar1"}))
 	require.NoError(t, err)
 
 	assert.Equal(t, "bar", cfg.SDKMetricsTags["foo"])
+	assert.Equal(t, "bar1", cfg.SDKMetricsTags["foo1"])
 }

--- a/senders/client_factory_test.go
+++ b/senders/client_factory_test.go
@@ -84,3 +84,10 @@ func TestTracesPort(t *testing.T) {
 
 	assert.Equal(t, 123, cfg.TracesPort)
 }
+
+func TestSDKMetricsTags(t *testing.T) {
+	cfg, err := senders.CreateConfig("https://localhost", senders.SDKMetricsTags(map[string]string{"foo": "bar"}))
+	require.NoError(t, err)
+
+	assert.Equal(t, "bar", cfg.SDKMetricsTags["foo"])
+}

--- a/senders/client_test.go
+++ b/senders/client_test.go
@@ -82,6 +82,9 @@ func TestSendDirect(t *testing.T) {
 	wf, err := senders.NewSender("http://" + token + "@localhost:" + wfPort)
 	require.NoError(t, err)
 	doTest(t, wf)
+	wf.Flush()
+	wf.Close()
+	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 	requests = map[string][]string{}
 }
 
@@ -91,14 +94,18 @@ func TestSendDirectWithTags(t *testing.T) {
 	require.NoError(t, err)
 	doTest(t, wf)
 
+	wf.Flush()
+	wf.Close()
+
 	flag := false
 	for _, request := range requests["8080"] {
 		if strings.Contains(request, "~sdk.go.core.sender.direct") && strings.Contains(request, "\"foo\"=\"bar\"") {
 			flag = true
 		}
 	}
-
 	assert.True(t, flag)
+
+	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 	requests = map[string][]string{}
 }
 
@@ -106,6 +113,10 @@ func TestSendProxy(t *testing.T) {
 	wf, err := senders.NewSender("http://localhost:" + proxyPort)
 	require.NoError(t, err)
 	doTest(t, wf)
+
+	wf.Flush()
+	wf.Close()
+	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 	requests = map[string][]string{}
 }
 
@@ -139,8 +150,4 @@ func doTest(t *testing.T, wf senders.Sender) {
 		nil); err != nil {
 		t.Error("Failed SendSpan", err)
 	}
-
-	wf.Flush()
-	wf.Close()
-	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 }

--- a/senders/client_test.go
+++ b/senders/client_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,42 +82,19 @@ func TestSendDirect(t *testing.T) {
 	wf, err := senders.NewSender("http://" + token + "@localhost:" + wfPort)
 	require.NoError(t, err)
 	doTest(t, wf)
-
-	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
-	wf.Flush()
-	wf.Close()
-	requests = map[string][]string{}
 }
 
 func TestSendDirectWithTags(t *testing.T) {
 	tags := map[string]string{"foo": "bar"}
-	wf, err := senders.NewSender("http://"+token+"@localhost:"+wfPort, senders.SDKMetricsTags(tags), senders.ReportTicker(time.Microsecond))
+	wf, err := senders.NewSender("http://"+token+"@localhost:"+wfPort, senders.SDKMetricsTags(tags))
 	require.NoError(t, err)
 	doTest(t, wf)
-
-	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
-	wf.Flush()
-	wf.Close()
-
-	flag := false
-	for _, request := range requests["8080"] {
-		if strings.Contains(request, "~sdk.go.core.sender.direct") && strings.Contains(request, "\"foo\"=\"bar\"") {
-			flag = true
-		}
-	}
-	assert.True(t, flag)
-	requests = map[string][]string{}
 }
 
 func TestSendProxy(t *testing.T) {
 	wf, err := senders.NewSender("http://localhost:" + proxyPort)
 	require.NoError(t, err)
 	doTest(t, wf)
-
-	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
-	wf.Flush()
-	wf.Close()
-	requests = map[string][]string{}
 }
 
 func doTest(t *testing.T, wf senders.Sender) {
@@ -151,4 +127,8 @@ func doTest(t *testing.T, wf senders.Sender) {
 		nil); err != nil {
 		t.Error("Failed SendSpan", err)
 	}
+
+	wf.Flush()
+	wf.Close()
+	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 }

--- a/senders/client_test.go
+++ b/senders/client_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,18 +83,20 @@ func TestSendDirect(t *testing.T) {
 	wf, err := senders.NewSender("http://" + token + "@localhost:" + wfPort)
 	require.NoError(t, err)
 	doTest(t, wf)
+
+	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 	wf.Flush()
 	wf.Close()
-	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 	requests = map[string][]string{}
 }
 
 func TestSendDirectWithTags(t *testing.T) {
 	tags := map[string]string{"foo": "bar"}
-	wf, err := senders.NewSender("http://"+token+"@localhost:"+wfPort, senders.SDKMetricsTags(tags), senders.ReportTicker(1))
+	wf, err := senders.NewSender("http://"+token+"@localhost:"+wfPort, senders.SDKMetricsTags(tags), senders.ReportTicker(time.Microsecond))
 	require.NoError(t, err)
 	doTest(t, wf)
 
+	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 	wf.Flush()
 	wf.Close()
 
@@ -104,8 +107,6 @@ func TestSendDirectWithTags(t *testing.T) {
 		}
 	}
 	assert.True(t, flag)
-
-	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 	requests = map[string][]string{}
 }
 
@@ -114,9 +115,9 @@ func TestSendProxy(t *testing.T) {
 	require.NoError(t, err)
 	doTest(t, wf)
 
+	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 	wf.Flush()
 	wf.Close()
-	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
 	requests = map[string][]string{}
 }
 

--- a/senders/client_test.go
+++ b/senders/client_test.go
@@ -58,6 +58,13 @@ func TestSendDirect(t *testing.T) {
 	doTest(t, wf)
 }
 
+func TestSendDirectWithTags(t *testing.T) {
+	tags := map[string]string{"foo": "bar"}
+	wf, err := senders.NewSender("http://"+token+"@localhost:"+wfPort, senders.SDKMetricsTags(tags))
+	require.NoError(t, err)
+	doTest(t, wf)
+}
+
 func TestSendProxy(t *testing.T) {
 	wf, err := senders.NewSender("http://localhost:" + proxyPort)
 	require.NoError(t, err)

--- a/senders/client_test.go
+++ b/senders/client_test.go
@@ -82,6 +82,7 @@ func TestSendDirect(t *testing.T) {
 	wf, err := senders.NewSender("http://" + token + "@localhost:" + wfPort)
 	require.NoError(t, err)
 	doTest(t, wf)
+	requests = map[string][]string{}
 }
 
 func TestSendDirectWithTags(t *testing.T) {
@@ -98,12 +99,14 @@ func TestSendDirectWithTags(t *testing.T) {
 	}
 
 	assert.True(t, flag)
+	requests = map[string][]string{}
 }
 
 func TestSendProxy(t *testing.T) {
 	wf, err := senders.NewSender("http://localhost:" + proxyPort)
 	require.NoError(t, err)
 	doTest(t, wf)
+	requests = map[string][]string{}
 }
 
 func doTest(t *testing.T, wf senders.Sender) {

--- a/senders/client_test.go
+++ b/senders/client_test.go
@@ -131,4 +131,24 @@ func doTest(t *testing.T, wf senders.Sender) {
 	wf.Flush()
 	wf.Close()
 	assert.Equal(t, int64(0), wf.GetFailureCount(), "GetFailureCount")
+
+	metricsFlag := false
+	hgFlag := false
+	spansFlag := false
+
+	for _, request := range requests["8080"] {
+		if strings.Contains(request, "new-york.power.usage") {
+			metricsFlag = true
+		}
+		if strings.Contains(request, "request.latency") {
+			hgFlag = true
+		}
+		if strings.Contains(request, "0313bafe-9457-11e8-9eb6-529269fb1459") {
+			spansFlag = true
+		}
+	}
+
+	assert.True(t, metricsFlag)
+	assert.True(t, hgFlag)
+	assert.True(t, spansFlag)
 }

--- a/senders/configs.go
+++ b/senders/configs.go
@@ -44,4 +44,5 @@ type ProxyConfiguration struct {
 	EventsPort       int // events port on which the proxy is listening on.
 
 	FlushIntervalSeconds int // defaults to 1 second
+	SDKMetricsTags       map[string]string
 }

--- a/senders/proxy.go
+++ b/senders/proxy.go
@@ -54,16 +54,18 @@ type proxySender struct {
 
 // Creates and returns a Wavefront Proxy Sender instance
 // Deprecated: Use 'senders.NewSender(url)'
-func NewProxySender(cfg *ProxyConfiguration) (Sender, error) {
+func NewProxySender(cfg *ProxyConfiguration, setters ...internal.RegistryOption) (Sender, error) {
 	sender := &proxySender{
 		defaultSource: internal.GetHostname("wavefront_proxy_sender"),
 		handlers:      make([]internal.ConnectionHandler, handlersCount),
 	}
 
+	setters = append(setters, internal.SetTag("pid", strconv.Itoa(os.Getpid())))
+	setters = append(setters, internal.SetPrefix("~sdk.go.core.sender.proxy"))
+
 	sender.internalRegistry = internal.NewMetricRegistry(
 		sender,
-		internal.SetPrefix("~sdk.go.core.sender.proxy"),
-		internal.SetTag("pid", strconv.Itoa(os.Getpid())),
+		setters...,
 	)
 
 	if sdkVersion, e := internal.GetSemVer(version.Version); e == nil {
@@ -131,6 +133,15 @@ func makeConnHandler(host string, port, flushIntervalSeconds int, prefix string,
 	addr := host + ":" + strconv.FormatInt(int64(port), 10)
 	flushInterval := time.Second * time.Duration(flushIntervalSeconds)
 	return internal.NewProxyConnectionHandler(addr, flushInterval, prefix, internalRegistry)
+}
+
+func SetTag(key, value string) internal.RegistryOption {
+	return func(registry *internal.MetricRegistry) {
+		if registry.Tags == nil {
+			registry.Tags = make(map[string]string)
+		}
+		registry.Tags[key] = value
+	}
 }
 
 func (sender *proxySender) Start() {

--- a/senders/proxy_test.go
+++ b/senders/proxy_test.go
@@ -81,3 +81,58 @@ func TestProxySends(t *testing.T) {
 		t.Error("FailureCount =", proxy.GetFailureCount())
 	}
 }
+
+func TestProxySendsWithTag(t *testing.T) {
+	proxyCfg := &senders.ProxyConfiguration{
+		Host:                 "localhost",
+		MetricsPort:          30000,
+		DistributionPort:     40000,
+		TracingPort:          50000,
+		FlushIntervalSeconds: 10,
+	}
+
+	setter := senders.SetTag("foo", "bar")
+	var err error
+	if proxy, err = senders.NewProxySender(proxyCfg, setter); err != nil {
+		t.Error("Failed Creating Sender", err)
+	}
+
+	if err = proxy.SendMetric("new-york.power.usage", 42422.0, 0, "go_test", map[string]string{"env": "test"}); err != nil {
+		t.Error("Failed SendMetric", err)
+	}
+	if err = proxy.SendDeltaCounter("lambda.thumbnail.generate", 10.0, "thumbnail_service", map[string]string{"format": "jpeg"}); err != nil {
+		t.Error("Failed SendDeltaCounter", err)
+	}
+
+	centroids := []histogram.Centroid{
+		{Value: 30.0, Count: 20},
+		{Value: 5.1, Count: 10},
+	}
+
+	hgs := map[histogram.Granularity]bool{
+		histogram.MINUTE: true,
+		histogram.HOUR:   true,
+		histogram.DAY:    true,
+	}
+
+	if err = proxy.SendDistribution("request.latency", centroids, hgs, 0, "appServer1", map[string]string{"region": "us-west"}); err != nil {
+		t.Error("Failed SendDistribution", err)
+	}
+
+	if err = proxy.SendSpan("getAllUsers", 0, 343500, "localhost",
+		"7b3bf470-9456-11e8-9eb6-529269fb1459", "0313bafe-9457-11e8-9eb6-529269fb1459",
+		[]string{"2f64e538-9457-11e8-9eb6-529269fb1459"}, nil,
+		[]senders.SpanTag{
+			{Key: "application", Value: "Wavefront"},
+			{Key: "http.method", Value: "GET"},
+		},
+		nil); err != nil {
+		t.Error("Failed SendSpan", err)
+	}
+
+	proxy.Flush()
+	proxy.Close()
+	if proxy.GetFailureCount() > 0 {
+		t.Error("FailureCount =", proxy.GetFailureCount())
+	}
+}

--- a/senders/proxy_test.go
+++ b/senders/proxy_test.go
@@ -22,13 +22,11 @@ func netcat(addr string, keepopen bool) {
 	lis.Close()
 }
 
-func init() {
+func TestProxySends(t *testing.T) {
 	go netcat("localhost:30000", false)
 	go netcat("localhost:40000", false)
 	go netcat("localhost:50000", false)
-}
 
-func TestProxySends(t *testing.T) {
 	proxyCfg := &senders.ProxyConfiguration{
 		Host:                 "localhost",
 		MetricsPort:          30000,
@@ -42,38 +40,7 @@ func TestProxySends(t *testing.T) {
 		t.Error("Failed Creating Sender", err)
 	}
 
-	if err = proxy.SendMetric("new-york.power.usage", 42422.0, 0, "go_test", map[string]string{"env": "test"}); err != nil {
-		t.Error("Failed SendMetric", err)
-	}
-	if err = proxy.SendDeltaCounter("lambda.thumbnail.generate", 10.0, "thumbnail_service", map[string]string{"format": "jpeg"}); err != nil {
-		t.Error("Failed SendDeltaCounter", err)
-	}
-
-	centroids := []histogram.Centroid{
-		{Value: 30.0, Count: 20},
-		{Value: 5.1, Count: 10},
-	}
-
-	hgs := map[histogram.Granularity]bool{
-		histogram.MINUTE: true,
-		histogram.HOUR:   true,
-		histogram.DAY:    true,
-	}
-
-	if err = proxy.SendDistribution("request.latency", centroids, hgs, 0, "appServer1", map[string]string{"region": "us-west"}); err != nil {
-		t.Error("Failed SendDistribution", err)
-	}
-
-	if err = proxy.SendSpan("getAllUsers", 0, 343500, "localhost",
-		"7b3bf470-9456-11e8-9eb6-529269fb1459", "0313bafe-9457-11e8-9eb6-529269fb1459",
-		[]string{"2f64e538-9457-11e8-9eb6-529269fb1459"}, nil,
-		[]senders.SpanTag{
-			{Key: "application", Value: "Wavefront"},
-			{Key: "http.method", Value: "GET"},
-		},
-		nil); err != nil {
-		t.Error("Failed SendSpan", err)
-	}
+	verifyResults(t, err)
 
 	proxy.Flush()
 	proxy.Close()
@@ -82,21 +49,35 @@ func TestProxySends(t *testing.T) {
 	}
 }
 
-func TestProxySendsWithTag(t *testing.T) {
+func TestProxySendsWithTags(t *testing.T) {
+	go netcat("localhost:30000", false)
+	go netcat("localhost:40000", false)
+	go netcat("localhost:50000", false)
+
 	proxyCfg := &senders.ProxyConfiguration{
 		Host:                 "localhost",
 		MetricsPort:          30000,
 		DistributionPort:     40000,
 		TracingPort:          50000,
 		FlushIntervalSeconds: 10,
+		SDKMetricsTags:       map[string]string{"foo": "bar"},
 	}
 
-	setter := senders.SetTag("foo", "bar")
 	var err error
-	if proxy, err = senders.NewProxySender(proxyCfg, setter); err != nil {
+	if proxy, err = senders.NewProxySender(proxyCfg); err != nil {
 		t.Error("Failed Creating Sender", err)
 	}
 
+	verifyResults(t, err)
+
+	proxy.Flush()
+	proxy.Close()
+	if proxy.GetFailureCount() > 0 {
+		t.Error("FailureCount =", proxy.GetFailureCount())
+	}
+}
+
+func verifyResults(t *testing.T, err error) {
 	if err = proxy.SendMetric("new-york.power.usage", 42422.0, 0, "go_test", map[string]string{"env": "test"}); err != nil {
 		t.Error("Failed SendMetric", err)
 	}
@@ -128,11 +109,5 @@ func TestProxySendsWithTag(t *testing.T) {
 		},
 		nil); err != nil {
 		t.Error("Failed SendSpan", err)
-	}
-
-	proxy.Flush()
-	proxy.Close()
-	if proxy.GetFailureCount() > 0 {
-		t.Error("FailureCount =", proxy.GetFailureCount())
 	}
 }

--- a/senders/proxy_test.go
+++ b/senders/proxy_test.go
@@ -26,6 +26,7 @@ func TestProxySends(t *testing.T) {
 	go netcat("localhost:40000", false)
 	go netcat("localhost:50000", false)
 
+	//TODO: need to check if there is a better way to avoid the race condition
 	time.Sleep(time.Second)
 	proxyCfg := &senders.ProxyConfiguration{
 		Host:                 "localhost",
@@ -55,6 +56,7 @@ func TestProxySendsWithTags(t *testing.T) {
 	go netcat("localhost:40000", false)
 	go netcat("localhost:50000", false)
 
+	//TODO: need to check if there is a better way to avoid the race condition
 	time.Sleep(time.Second)
 
 	proxyCfg := &senders.ProxyConfiguration{

--- a/senders/proxy_test.go
+++ b/senders/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/wavefronthq/wavefront-sdk-go/histogram"
 	"github.com/wavefronthq/wavefront-sdk-go/senders"
@@ -27,6 +28,7 @@ func TestProxySends(t *testing.T) {
 	go netcat("localhost:40000", false)
 	go netcat("localhost:50000", false)
 
+	time.Sleep(time.Second)
 	proxyCfg := &senders.ProxyConfiguration{
 		Host:                 "localhost",
 		MetricsPort:          30000,
@@ -53,6 +55,8 @@ func TestProxySendsWithTags(t *testing.T) {
 	go netcat("localhost:30000", false)
 	go netcat("localhost:40000", false)
 	go netcat("localhost:50000", false)
+
+	time.Sleep(time.Second)
 
 	proxyCfg := &senders.ProxyConfiguration{
 		Host:                 "localhost",

--- a/senders/proxy_test.go
+++ b/senders/proxy_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/wavefronthq/wavefront-sdk-go/senders"
 )
 
-var proxy senders.Sender
-
 func netcat(addr string, keepopen bool) {
 	laddr, _ := net.ResolveTCPAddr("tcp", addr)
 	lis, _ := net.ListenTCP("tcp", laddr)
@@ -38,11 +36,12 @@ func TestProxySends(t *testing.T) {
 	}
 
 	var err error
+	var proxy senders.Sender
 	if proxy, err = senders.NewProxySender(proxyCfg); err != nil {
 		t.Error("Failed Creating Sender", err)
 	}
 
-	verifyResults(t, err)
+	verifyResults(t, err, proxy)
 
 	proxy.Flush()
 	proxy.Close()
@@ -68,11 +67,12 @@ func TestProxySendsWithTags(t *testing.T) {
 	}
 
 	var err error
+	var proxy senders.Sender
 	if proxy, err = senders.NewProxySender(proxyCfg); err != nil {
 		t.Error("Failed Creating Sender", err)
 	}
 
-	verifyResults(t, err)
+	verifyResults(t, err, proxy)
 
 	proxy.Flush()
 	proxy.Close()
@@ -81,7 +81,7 @@ func TestProxySendsWithTags(t *testing.T) {
 	}
 }
 
-func verifyResults(t *testing.T, err error) {
+func verifyResults(t *testing.T, err error, proxy senders.Sender) {
 	if err = proxy.SendMetric("new-york.power.usage", 42422.0, 0, "go_test", map[string]string{"env": "test"}); err != nil {
 		t.Error("Failed SendMetric", err)
 	}

--- a/senders/proxy_test.go
+++ b/senders/proxy_test.go
@@ -1,14 +1,12 @@
 package senders_test
 
 import (
+	"github.com/wavefronthq/wavefront-sdk-go/histogram"
+	"github.com/wavefronthq/wavefront-sdk-go/senders"
 	"io"
 	"net"
 	"os"
 	"testing"
-	"time"
-
-	"github.com/wavefronthq/wavefront-sdk-go/histogram"
-	"github.com/wavefronthq/wavefront-sdk-go/senders"
 )
 
 func netcat(addr string, keepopen bool) {
@@ -26,8 +24,6 @@ func TestProxySends(t *testing.T) {
 	go netcat("localhost:40000", false)
 	go netcat("localhost:50000", false)
 
-	//TODO: need to check if there is a better way to avoid the race condition
-	time.Sleep(time.Second)
 	proxyCfg := &senders.ProxyConfiguration{
 		Host:                 "localhost",
 		MetricsPort:          30000,
@@ -55,9 +51,6 @@ func TestProxySendsWithTags(t *testing.T) {
 	go netcat("localhost:30000", false)
 	go netcat("localhost:40000", false)
 	go netcat("localhost:50000", false)
-
-	//TODO: need to check if there is a better way to avoid the race condition
-	time.Sleep(time.Second)
 
 	proxyCfg := &senders.ProxyConfiguration{
 		Host:                 "localhost",


### PR DESCRIPTION
Update newProxySender to take an additional setter with Otel tag set by
the Otel-Collector.