### PR TITLE
bug: address parsing wavefront urls with a path component

### DIFF
--- a/internal/reporter_test.go
+++ b/internal/reporter_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -9,9 +8,8 @@ import (
 
 func TestBuildRequest(t *testing.T) {
 	var r *reporter
-	var buf bytes.Buffer
 	r = NewReporter("http://localhost:8010/wavefront", "").(*reporter)
-	request, err := r.buildRequest("wavefront", buf)
+	request, err := r.buildRequest("wavefront", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:8010/wavefront/report?f=wavefront", request.URL.String())
 }

--- a/internal/reporter_test.go
+++ b/internal/reporter_test.go
@@ -1,0 +1,17 @@
+package internal
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestBuildRequest(t *testing.T) {
+	var r *reporter
+	var buf bytes.Buffer
+	r = NewReporter("http://localhost:8010/wavefront", "").(*reporter)
+	request, err := r.buildRequest("wavefront", buf)
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8010/wavefront/report?f=wavefront", request.URL.String())
+}

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -130,8 +130,8 @@ func CreateConfig(wfURL string, setters ...Option) (*configuration, error) {
 
 // newWavefrontClient creates a Wavefront sender
 func newWavefrontClient(cfg *configuration) (Sender, error) {
-	metricsReporter := internal.NewReporter(MetricsURL(cfg), cfg.Token)
-	tracesReporter := internal.NewReporter(TracesURL(cfg), cfg.Token)
+	metricsReporter := internal.NewReporter(cfg.MetricsURL(), cfg.Token)
+	tracesReporter := internal.NewReporter(cfg.TracesURL(), cfg.Token)
 
 	sender := &wavefrontSender{
 		defaultSource: internal.GetHostname("wavefront_direct_sender"),
@@ -148,11 +148,11 @@ func newWavefrontClient(cfg *configuration) (Sender, error) {
 	return sender, nil
 }
 
-func TracesURL(cfg *configuration) string {
+func (cfg *configuration) TracesURL() string {
 	return fmt.Sprintf("%s:%d%s", cfg.Server, cfg.TracesPort, cfg.Path)
 }
 
-func MetricsURL(cfg *configuration) string {
+func (cfg *configuration) MetricsURL() string {
 	return fmt.Sprintf("%s:%d%s", cfg.Server, cfg.MetricsPort, cfg.Path)
 }
 

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -44,6 +44,7 @@ type configuration struct {
 	// together with batch size controls the max theoretical throughput of the sender.
 	FlushIntervalSeconds int
 	SDKMetricsTags       map[string]string
+	Path                 string
 }
 
 func (c *configuration) Direct() bool {
@@ -106,6 +107,11 @@ func CreateConfig(wfURL string, setters ...Option) (*configuration, error) {
 		return nil, fmt.Errorf("invalid scheme '%s' in '%s', only 'http' is supported", u.Scheme, u)
 	}
 
+	if u.Path != "" {
+		cfg.Path = u.Path
+		u.Path = ""
+	}
+
 	if u.Port() != "" {
 		port, err := strconv.Atoi(u.Port())
 		if err != nil {
@@ -124,8 +130,8 @@ func CreateConfig(wfURL string, setters ...Option) (*configuration, error) {
 
 // newWavefrontClient creates a Wavefront sender
 func newWavefrontClient(cfg *configuration) (Sender, error) {
-	metricsReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.MetricsPort), cfg.Token)
-	tracesReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.TracesPort), cfg.Token)
+	metricsReporter := internal.NewReporter(MetricsURL(cfg), cfg.Token)
+	tracesReporter := internal.NewReporter(TracesURL(cfg), cfg.Token)
 
 	sender := &wavefrontSender{
 		defaultSource: internal.GetHostname("wavefront_direct_sender"),
@@ -140,6 +146,14 @@ func newWavefrontClient(cfg *configuration) (Sender, error) {
 
 	sender.Start()
 	return sender, nil
+}
+
+func TracesURL(cfg *configuration) string {
+	return fmt.Sprintf("%s:%d%s", cfg.Server, cfg.TracesPort, cfg.Path)
+}
+
+func MetricsURL(cfg *configuration) string {
+	return fmt.Sprintf("%s:%d%s", cfg.Server, cfg.MetricsPort, cfg.Path)
 }
 
 func (sender *wavefrontSender) initializeInternalMetrics(cfg *configuration) {

--- a/senders/client_factory_test.go
+++ b/senders/client_factory_test.go
@@ -65,6 +65,22 @@ func TestPortExtractedFromURL(t *testing.T) {
 	assert.Equal(t, 1234, cfg.TracesPort)
 }
 
+func TestUrlWithPortAndPath(t *testing.T) {
+	cfg, err := senders.CreateConfig("http://localhost:8071/wavefront")
+	require.NoError(t, err)
+	assert.Equal(t, 8071, cfg.MetricsPort)
+	assert.Equal(t, 8071, cfg.TracesPort)
+	assert.Equal(t, "http://localhost", cfg.Server)
+	assert.Equal(t, "/wavefront", cfg.Path)
+}
+
+func TestMetricsURLWithPortAndPath(t *testing.T) {
+	cfg, err := senders.CreateConfig("http://localhost:8071/wavefront")
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8071/wavefront", senders.MetricsURL(cfg))
+	assert.Equal(t, "http://localhost:8071/wavefront", senders.TracesURL(cfg))
+}
+
 func TestToken(t *testing.T) {
 	cfg, err := senders.CreateConfig("https://my-api-token@localhost")
 	require.NoError(t, err)

--- a/senders/client_factory_test.go
+++ b/senders/client_factory_test.go
@@ -77,8 +77,8 @@ func TestUrlWithPortAndPath(t *testing.T) {
 func TestMetricsURLWithPortAndPath(t *testing.T) {
 	cfg, err := senders.CreateConfig("http://localhost:8071/wavefront")
 	require.NoError(t, err)
-	assert.Equal(t, "http://localhost:8071/wavefront", senders.MetricsURL(cfg))
-	assert.Equal(t, "http://localhost:8071/wavefront", senders.TracesURL(cfg))
+	assert.Equal(t, "http://localhost:8071/wavefront", cfg.MetricsURL())
+	assert.Equal(t, "http://localhost:8071/wavefront", cfg.TracesURL())
 }
 
 func TestToken(t *testing.T) {


### PR DESCRIPTION
resolves: #108

This PR adds a "Path" field to the `configuration` struct so that we can stash the path component of a URL there and use it to correctly reconstruct a URL later.

I would be interested in suggestions about the `MetricsURL` and `TracesURL` methods; I think exporting these is a little bit unfortunate, but the url construction is important to test and is currently a little hard to exercise in a test because it's happening inside unexported functions. We could refactor to make this easier to test, but I didn't want to increase the scope of the PR for this fix.

This supports usecases where rather than talking to a WF instances or proxy directly, we are communicating through some sort of proxy that does path-based routing of our requests.

@keep94 @oppegard thanks in advance for your eyes on this PR 🙇‍♂️

cc: @rushikeshbgithub
