### PR TITLE
testing: add a basic integration test

### DIFF
--- a/senders/integration_test.go
+++ b/senders/integration_test.go
@@ -1,0 +1,19 @@
+package senders
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestEndToEnd(t *testing.T) {
+	testServer := startTestServer()
+	defer testServer.Close()
+	sender, err := NewSender(testServer.URL)
+	require.NoError(t, err)
+	require.NoError(t, sender.SendMetric("my metric", 20, 0, "localhost", nil))
+	require.NoError(t, sender.Flush())
+
+	assert.Equal(t, 1, len(testServer.MetricLines))
+	assert.Equal(t, "\"my-metric\" 20 source=\"localhost\"", testServer.MetricLines[0])
+}

--- a/senders/test_server_test.go
+++ b/senders/test_server_test.go
@@ -1,0 +1,54 @@
+package senders
+
+import (
+	"bufio"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+)
+
+func startTestServer() *testServer {
+	handler := &testServer{}
+	server := httptest.NewServer(handler)
+	handler.httpServer = server
+	handler.URL = server.URL
+	return handler
+
+}
+
+type testServer struct {
+	MetricLines []string
+	httpServer  *httptest.Server
+	URL         string
+}
+
+func (s *testServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	newLines, err := decodeMetricLines(request)
+	if err != nil {
+		writer.WriteHeader(500)
+	}
+	s.MetricLines = append(s.MetricLines, newLines...)
+	writer.WriteHeader(200)
+}
+
+func decodeMetricLines(request *http.Request) ([]string, error) {
+	var metricLines []string
+	reader, err := gzip.NewReader(request.Body)
+	if err != nil {
+		return metricLines, err
+	}
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := scanner.Text()
+		metricLines = append(metricLines, line)
+	}
+	if scanner.Err() != nil {
+		reader.Close()
+		return metricLines, scanner.Err()
+	}
+	return metricLines, reader.Close()
+}
+
+func (s *testServer) Close() {
+	s.httpServer.Close()
+}


### PR DESCRIPTION
In the process of working on #109 , I was worried about not having automated end-to-end test coverage, and I thought that even a simple test against a local http server might make it easier to refactor the sdk internals with greater confidence.

@keep94 what do you think?

cc: @suprajanarasimhan @ktollivervmw 