### PR TITLE
Handle server url parsing containing path.

### DIFF
--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -124,8 +124,12 @@ func CreateConfig(wfURL string, setters ...Option) (*configuration, error) {
 
 // newWavefrontClient creates a Wavefront sender
 func newWavefrontClient(cfg *configuration) (Sender, error) {
-	metricsReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.MetricsPort), cfg.Token)
-	tracesReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.TracesPort), cfg.Token)
+	u, err := url.Parse(cfg.Server)
+	if err != nil {
+		return nil, err
+	}
+	metricsReporter := internal.NewReporter(fmt.Sprintf("%s://%s:%d%s", u.Scheme, u.Host, cfg.MetricsPort, u.Path), cfg.Token)
+	tracesReporter := internal.NewReporter(fmt.Sprintf("%s://%s:%d%s", u.Scheme, u.Host, cfg.TracesPort, u.Path), cfg.Token)
 
 	sender := &wavefrontSender{
 		defaultSource: internal.GetHostname("wavefront_direct_sender"),

--- a/senders/client_test.go
+++ b/senders/client_test.go
@@ -95,12 +95,14 @@ func readBodyIntoString(r *http.Request) {
 }
 
 func TestSendDirect(t *testing.T) {
+	requests = nil
 	wf, err := senders.NewSender("http://" + token + "@localhost:" + wfPort)
 	require.NoError(t, err)
 	doTest(t, wf)
 }
 
 func TestSendDirectWithTags(t *testing.T) {
+	requests = nil
 	tags := map[string]string{"foo": "bar"}
 	wf, err := senders.NewSender("http://"+token+"@localhost:"+wfPort, senders.SDKMetricsTags(tags))
 	require.NoError(t, err)
@@ -108,7 +110,15 @@ func TestSendDirectWithTags(t *testing.T) {
 }
 
 func TestSendProxy(t *testing.T) {
+	requests = nil
 	wf, err := senders.NewSender("http://localhost:" + proxyPort)
+	require.NoError(t, err)
+	doTest(t, wf)
+}
+
+func TestSendProxyWithPath(t *testing.T) {
+	requests = nil
+	wf, err := senders.NewSender("http://localhost:" + proxyPort + "/metrics")
 	require.NoError(t, err)
 	doTest(t, wf)
 }


### PR DESCRIPTION
Fix for #108 
Handle server url parsing containing path. Added a test for same in client_test.go.
Multiple tests in client_test.go verify metrics against same "requests" array. So Making requests array nil in all test function to ensure single test failure is flagged if any.