### PR TITLE
Make Sender so that it can't be implemented externally.

### DIFF
--- a/senders/client.go
+++ b/senders/client.go
@@ -17,6 +17,7 @@ type Sender interface {
 	EventSender
 	internal.Flusher
 	Close()
+	private()
 }
 
 type wavefrontSender struct {
@@ -72,6 +73,9 @@ func (sender *wavefrontSender) Start() {
 	sender.spanLogHandler.Start()
 	sender.internalRegistry.Start()
 	sender.eventHandler.Start()
+}
+
+func (sender *wavefrontSender) private() {
 }
 
 func (sender *wavefrontSender) SendMetric(name string, value float64, ts int64, source string, tags map[string]string) error {

--- a/senders/client_multi.go
+++ b/senders/client_multi.go
@@ -54,6 +54,9 @@ func NewMultiSender(senders ...Sender) MultiSender {
 	return ms
 }
 
+func (ms *multiSender) private() {
+}
+
 func (ms *multiSender) SendMetric(name string, value float64, ts int64, source string, tags map[string]string) error {
 	var errors multiError
 	for _, sender := range ms.senders {

--- a/senders/client_noop.go
+++ b/senders/client_noop.go
@@ -17,6 +17,9 @@ func NewWavefrontNoOpClient() (Sender, error) {
 	return defaultNoopClient, nil
 }
 
+func (sender *wavefrontNoOpSender) private() {
+}
+
 func (sender *wavefrontNoOpSender) Start() {
 	// no-op
 }


### PR DESCRIPTION
This is another way to ensure that we can add methods to Sender as non-breaking changes.  This works but it is weird because we declare a 9 method interface in GO, a language where interfaces with just 1 or 2 methods are common. Also, note that there is not a way to write examples for interface methods in GO. I think this is by design.

The up side to this solution is that it won't break most existing clients.