### PR TITLE
Make request timeout and TLS properties configurable.

### DIFF
--- a/internal/reporter.go
+++ b/internal/reporter.go
@@ -28,14 +28,11 @@ func NewReporter(server string, token string, client *http.Client) Reporter {
 }
 
 func NewClient(timeout time.Duration, tlsConfig *tls.Config) *http.Client {
-	var client *http.Client
 	if tlsConfig == nil {
-		client = &http.Client{Timeout: timeout}
+		return &http.Client{Timeout: timeout}
 	}
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
-	client = &http.Client{Timeout: timeout, Transport: transport}
-
-	return client
+	return &http.Client{Timeout: timeout, Transport: transport}
 }
 
 // Report creates and sends a POST to the reportEndpoint with the given pointLines

--- a/internal/reporter.go
+++ b/internal/reporter.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/tls"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -18,11 +19,20 @@ type reporter struct {
 }
 
 // NewReporter create a metrics Reporter
-func NewReporter(server string, token string) Reporter {
+func NewReporter(server string, token string, timeout time.Duration, tlsConfigOptions *tls.Config) Reporter {
+
+	var client *http.Client
+	if tlsConfigOptions == nil {
+		client = &http.Client{Timeout: timeout}
+	} else {
+		transport := &http.Transport{TLSClientConfig: tlsConfigOptions}
+		client = &http.Client{Timeout: timeout, Transport: transport}
+	}
+
 	return &reporter{
 		serverURL: server,
 		token:     token,
-		client:    &http.Client{Timeout: time.Second * 10},
+		client:    client,
 	}
 }
 

--- a/internal/reporter.go
+++ b/internal/reporter.go
@@ -18,9 +18,16 @@ type reporter struct {
 	client    *http.Client
 }
 
-// NewReporter create a metrics Reporter
-func NewReporter(server string, token string, timeout time.Duration, tlsConfigOptions *tls.Config) Reporter {
+// NewReporter creates a metrics Reporter
+func NewReporter(server string, token string, client *http.Client) Reporter {
+	return &reporter{
+		serverURL: server,
+		token:     token,
+		client:    client,
+	}
+}
 
+func NewClient(timeout time.Duration, tlsConfigOptions *tls.Config) *http.Client {
 	var client *http.Client
 	if tlsConfigOptions == nil {
 		client = &http.Client{Timeout: timeout}
@@ -28,12 +35,7 @@ func NewReporter(server string, token string, timeout time.Duration, tlsConfigOp
 		transport := &http.Transport{TLSClientConfig: tlsConfigOptions}
 		client = &http.Client{Timeout: timeout, Transport: transport}
 	}
-
-	return &reporter{
-		serverURL: server,
-		token:     token,
-		client:    client,
-	}
+	return client
 }
 
 // Report creates and sends a POST to the reportEndpoint with the given pointLines

--- a/internal/reporter.go
+++ b/internal/reporter.go
@@ -27,12 +27,12 @@ func NewReporter(server string, token string, client *http.Client) Reporter {
 	}
 }
 
-func NewClient(timeout time.Duration, tlsConfigOptions *tls.Config) *http.Client {
+func NewClient(timeout time.Duration, tlsConfig *tls.Config) *http.Client {
 	var client *http.Client
-	if tlsConfigOptions == nil {
+	if tlsConfig == nil {
 		client = &http.Client{Timeout: timeout}
 	} else {
-		transport := &http.Transport{TLSClientConfig: tlsConfigOptions}
+		transport := &http.Transport{TLSClientConfig: tlsConfig}
 		client = &http.Client{Timeout: timeout, Transport: transport}
 	}
 	return client

--- a/internal/reporter.go
+++ b/internal/reporter.go
@@ -31,10 +31,10 @@ func NewClient(timeout time.Duration, tlsConfig *tls.Config) *http.Client {
 	var client *http.Client
 	if tlsConfig == nil {
 		client = &http.Client{Timeout: timeout}
-	} else {
-		transport := &http.Transport{TLSClientConfig: tlsConfig}
-		client = &http.Client{Timeout: timeout, Transport: transport}
 	}
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	client = &http.Client{Timeout: timeout, Transport: transport}
+
 	return client
 }
 

--- a/internal/reporter_test.go
+++ b/internal/reporter_test.go
@@ -1,10 +1,13 @@
 package internal
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestBuildRequest(t *testing.T) {
@@ -13,4 +16,29 @@ func TestBuildRequest(t *testing.T) {
 	request, err := r.buildRequest("wavefront", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:8010/wavefront/report?f=wavefront", request.URL.String())
+}
+
+func TestNewClientWithNilTLSConfig(t *testing.T) {
+	client := NewClient(10*time.Second, nil)
+	assert.Equal(t, nil, client.Transport)
+}
+
+func TestNewClientWithCustomTLSConfig(t *testing.T) {
+	caCertPool := x509.NewCertPool()
+	fakeCert := []byte("Not a real cert")
+	caCertPool.AppendCertsFromPEM(fakeCert)
+
+	tlsConfig := &tls.Config{
+		RootCAs: caCertPool,
+	}
+
+	emptyTLSConfig := &tls.Config{}
+
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	transportWithEmptyTLSConfig := &http.Transport{TLSClientConfig: emptyTLSConfig}
+
+	client := NewClient(10*time.Second, tlsConfig)
+	assert.Equal(t, transport, client.Transport)
+	assert.NotEqual(t, transportWithEmptyTLSConfig, client.Transport)
+
 }

--- a/internal/reporter_test.go
+++ b/internal/reporter_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestBuildRequest(t *testing.T) {
 	var r *reporter
-	r = NewReporter("http://localhost:8010/wavefront", "").(*reporter)
+	r = NewReporter("http://localhost:8010/wavefront", "", 0, nil).(*reporter)
 	request, err := r.buildRequest("wavefront", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:8010/wavefront/report?f=wavefront", request.URL.String())

--- a/internal/reporter_test.go
+++ b/internal/reporter_test.go
@@ -3,12 +3,13 @@ package internal
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"net/http"
 	"testing"
 )
 
 func TestBuildRequest(t *testing.T) {
 	var r *reporter
-	r = NewReporter("http://localhost:8010/wavefront", "", 0, nil).(*reporter)
+	r = NewReporter("http://localhost:8010/wavefront", "", &http.Client{}).(*reporter)
 	request, err := r.buildRequest("wavefront", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:8010/wavefront/report?f=wavefront", request.URL.String())

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -247,8 +247,9 @@ func Timeout(timeout time.Duration) Option {
 }
 
 func TLSConfigOptions(tlsCfg *tls.Config) Option {
+	tlsCfgCopy := tlsCfg.Clone()
 	return func(cfg *configuration) {
-		cfg.TLSConfigOptions = tlsCfg
+		cfg.TLSConfigOptions = tlsCfgCopy
 	}
 }
 

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -141,8 +141,9 @@ func CreateConfig(wfURL string, setters ...Option) (*configuration, error) {
 
 // newWavefrontClient creates a Wavefront sender
 func newWavefrontClient(cfg *configuration) (Sender, error) {
-	metricsReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.MetricsPort), cfg.Token, cfg.Timeout, cfg.TLSConfigOptions)
-	tracesReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.TracesPort), cfg.Token, cfg.Timeout, cfg.TLSConfigOptions)
+	client := internal.NewClient(cfg.Timeout, cfg.TLSConfigOptions)
+	metricsReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.MetricsPort), cfg.Token, client)
+	tracesReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.TracesPort), cfg.Token, client)
 
 	sender := &wavefrontSender{
 		defaultSource: internal.GetHostname("wavefront_direct_sender"),

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -1,11 +1,13 @@
 package senders
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/wavefronthq/wavefront-sdk-go/internal"
 	"github.com/wavefronthq/wavefront-sdk-go/version"
@@ -17,6 +19,7 @@ const (
 	defaultBatchSize     = 10000
 	defaultBufferSize    = 50000
 	defaultFlushInterval = 1
+	defaultTimeout       = 10 * time.Second
 )
 
 // Option Wavefront client configuration options
@@ -48,6 +51,10 @@ type configuration struct {
 	FlushIntervalSeconds int
 	SDKMetricsTags       map[string]string
 	Path                 string
+
+	Timeout time.Duration
+
+	TLSConfigOptions *tls.Config
 }
 
 func (c *configuration) Direct() bool {
@@ -85,6 +92,7 @@ func CreateConfig(wfURL string, setters ...Option) (*configuration, error) {
 		MaxBufferSize:        defaultBufferSize,
 		FlushIntervalSeconds: defaultFlushInterval,
 		SDKMetricsTags:       map[string]string{},
+		Timeout:              defaultTimeout,
 	}
 
 	u, err := url.Parse(wfURL)
@@ -133,8 +141,8 @@ func CreateConfig(wfURL string, setters ...Option) (*configuration, error) {
 
 // newWavefrontClient creates a Wavefront sender
 func newWavefrontClient(cfg *configuration) (Sender, error) {
-	metricsReporter := internal.NewReporter(cfg.MetricsURL(), cfg.Token)
-	tracesReporter := internal.NewReporter(cfg.TracesURL(), cfg.Token)
+	metricsReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.MetricsPort), cfg.Token, cfg.Timeout, cfg.TLSConfigOptions)
+	tracesReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.TracesPort), cfg.Token, cfg.Timeout, cfg.TLSConfigOptions)
 
 	sender := &wavefrontSender{
 		defaultSource: internal.GetHostname("wavefront_direct_sender"),
@@ -227,6 +235,19 @@ func MetricsPort(port int) Option {
 func TracesPort(port int) Option {
 	return func(cfg *configuration) {
 		cfg.TracesPort = port
+	}
+}
+
+// Timeout sets the HTTP timeout (in seconds). Defaults to 10 seconds.
+func Timeout(timeout time.Duration) Option {
+	return func(cfg *configuration) {
+		cfg.Timeout = timeout
+	}
+}
+
+func TLSConfigOptions(tlsCfg *tls.Config) Option {
+	return func(cfg *configuration) {
+		cfg.TLSConfigOptions = tlsCfg
 	}
 }
 

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -54,7 +54,7 @@ type configuration struct {
 
 	Timeout time.Duration
 
-	TLSConfigOptions *tls.Config
+	TLSConfig *tls.Config
 }
 
 func (c *configuration) Direct() bool {
@@ -141,7 +141,7 @@ func CreateConfig(wfURL string, setters ...Option) (*configuration, error) {
 
 // newWavefrontClient creates a Wavefront sender
 func newWavefrontClient(cfg *configuration) (Sender, error) {
-	client := internal.NewClient(cfg.Timeout, cfg.TLSConfigOptions)
+	client := internal.NewClient(cfg.Timeout, cfg.TLSConfig)
 	metricsReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.MetricsPort), cfg.Token, client)
 	tracesReporter := internal.NewReporter(fmt.Sprintf("%s:%d", cfg.Server, cfg.TracesPort), cfg.Token, client)
 
@@ -246,10 +246,10 @@ func Timeout(timeout time.Duration) Option {
 	}
 }
 
-func TLSConfigOptions(tlsCfg *tls.Config) Option {
+func TLSConfigOptions(tlsCfg tls.Config) Option {
 	tlsCfgCopy := tlsCfg.Clone()
 	return func(cfg *configuration) {
-		cfg.TLSConfigOptions = tlsCfgCopy
+		cfg.TLSConfig = tlsCfgCopy
 	}
 }
 

--- a/senders/client_factory.go
+++ b/senders/client_factory.go
@@ -246,7 +246,7 @@ func Timeout(timeout time.Duration) Option {
 	}
 }
 
-func TLSConfigOptions(tlsCfg tls.Config) Option {
+func TLSConfigOptions(tlsCfg *tls.Config) Option {
 	tlsCfgCopy := tlsCfg.Clone()
 	return func(cfg *configuration) {
 		cfg.TLSConfig = tlsCfgCopy

--- a/senders/client_factory_test.go
+++ b/senders/client_factory_test.go
@@ -163,7 +163,7 @@ func TestTLSConfigOptions(t *testing.T) {
 	tlsConfig := tls.Config{
 		RootCAs: caCertPool,
 	}
-	cfg, err := senders.CreateConfig("https://localhost", senders.TLSConfigOptions(tlsConfig))
+	cfg, err := senders.CreateConfig("https://localhost", senders.TLSConfigOptions(&tlsConfig))
 	require.NoError(t, err)
 	assert.Equal(t, caCertPool, cfg.TLSConfig.RootCAs)
 }

--- a/senders/client_factory_test.go
+++ b/senders/client_factory_test.go
@@ -102,7 +102,7 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, 2878, cfg.MetricsPort)
 	assert.Equal(t, 30001, cfg.TracesPort)
 	assert.Equal(t, 10*time.Second, cfg.Timeout)
-	assert.Equal(t, (*tls.Config)(nil), cfg.TLSConfigOptions)
+	assert.Equal(t, (*tls.Config)(nil), cfg.TLSConfig)
 }
 
 func TestBatchSize(t *testing.T) {
@@ -160,12 +160,12 @@ func TestTLSConfigOptions(t *testing.T) {
 	fakeCert := []byte("Not a real cert")
 	caCertPool.AppendCertsFromPEM(fakeCert)
 
-	tlsConfig := &tls.Config{
+	tlsConfig := tls.Config{
 		RootCAs: caCertPool,
 	}
 	cfg, err := senders.CreateConfig("https://localhost", senders.TLSConfigOptions(tlsConfig))
 	require.NoError(t, err)
-	assert.Equal(t, caCertPool, cfg.TLSConfigOptions.RootCAs)
+	assert.Equal(t, caCertPool, cfg.TLSConfig.RootCAs)
 }
 
 func TestSDKMetricsTags_Immutability(t *testing.T) {

--- a/senders/example_newsender_options_test.go
+++ b/senders/example_newsender_options_test.go
@@ -1,6 +1,7 @@
 package senders_test
 
 import (
+	"crypto/tls"
 	wavefront "github.com/wavefronthq/wavefront-sdk-go/senders"
 )
 
@@ -8,10 +9,12 @@ func ExampleNewSender_options() {
 	// NewSender accepts optional arguments. Use these if you need to set non-default ports for your Wavefront Proxy, tune batching parameters, or set tags for internal SDK metrics.
 	sender, err := wavefront.NewSender(
 		"http://localhost",
-		wavefront.BatchSize(20000),        // Send batches of 20,000.
-		wavefront.FlushIntervalSeconds(5), // Flush every 5 seconds.
-		wavefront.MetricsPort(4321),       // Use port 4321 for metrics.
-		wavefront.TracesPort(40001),       // Use port 40001 for traces.
+		wavefront.BatchSize(20000),                // Send batches of 20,000.
+		wavefront.FlushIntervalSeconds(5),         // Flush every 5 seconds.
+		wavefront.MetricsPort(4321),               // Use port 4321 for metrics.
+		wavefront.TracesPort(40001),               // Use port 40001 for traces.
+		wavefront.Timeout(15),                     // Set an HTTP timeout in seconds (default is 10s)
+		wavefront.TLSConfigOptions(&tls.Config{}), // Set TLS config options.
 	)
 
 	if err != nil {

--- a/senders/integration_test.go
+++ b/senders/integration_test.go
@@ -17,3 +17,18 @@ func TestEndToEnd(t *testing.T) {
 	assert.Equal(t, 1, len(testServer.MetricLines))
 	assert.Equal(t, "\"my-metric\" 20 source=\"localhost\"", testServer.MetricLines[0])
 }
+
+func TestTLSEndToEnd(t *testing.T) {
+	testServer := startTLSTestServer()
+	defer testServer.Close()
+	testServer.httpServer.Client()
+	tlsConfig := testServer.TLSConfig()
+
+	sender, err := NewSender(testServer.URL, TLSConfigOptions(tlsConfig))
+	require.NoError(t, err)
+	require.NoError(t, sender.SendMetric("my metric", 20, 0, "localhost", nil))
+	require.NoError(t, sender.Flush())
+
+	assert.Equal(t, 1, len(testServer.MetricLines))
+	assert.Equal(t, "\"my-metric\" 20 source=\"localhost\"", testServer.MetricLines[0])
+}

--- a/senders/integration_test.go
+++ b/senders/integration_test.go
@@ -24,7 +24,7 @@ func TestTLSEndToEnd(t *testing.T) {
 	testServer.httpServer.Client()
 	tlsConfig := testServer.TLSConfig()
 
-	sender, err := NewSender(testServer.URL, TLSConfigOptions(&tlsConfig))
+	sender, err := NewSender(testServer.URL, TLSConfigOptions(tlsConfig))
 	require.NoError(t, err)
 	require.NoError(t, sender.SendMetric("my metric", 20, 0, "localhost", nil))
 	require.NoError(t, sender.Flush())

--- a/senders/integration_test.go
+++ b/senders/integration_test.go
@@ -24,7 +24,7 @@ func TestTLSEndToEnd(t *testing.T) {
 	testServer.httpServer.Client()
 	tlsConfig := testServer.TLSConfig()
 
-	sender, err := NewSender(testServer.URL, TLSConfigOptions(tlsConfig))
+	sender, err := NewSender(testServer.URL, TLSConfigOptions(&tlsConfig))
 	require.NoError(t, err)
 	require.NoError(t, sender.SendMetric("my metric", 20, 0, "localhost", nil))
 	require.NoError(t, sender.Flush())

--- a/senders/test_server_test.go
+++ b/senders/test_server_test.go
@@ -32,10 +32,10 @@ type testServer struct {
 	URL         string
 }
 
-func (s *testServer) TLSConfig() *tls.Config {
+func (s *testServer) TLSConfig() tls.Config {
 	certpool := x509.NewCertPool()
 	certpool.AddCert(s.httpServer.Certificate())
-	return &tls.Config{
+	return tls.Config{
 		RootCAs: certpool,
 	}
 }

--- a/senders/test_server_test.go
+++ b/senders/test_server_test.go
@@ -32,10 +32,10 @@ type testServer struct {
 	URL         string
 }
 
-func (s *testServer) TLSConfig() tls.Config {
+func (s *testServer) TLSConfig() *tls.Config {
 	certpool := x509.NewCertPool()
 	certpool.AddCert(s.httpServer.Certificate())
-	return tls.Config{
+	return &tls.Config{
 		RootCAs: certpool,
 	}
 }


### PR DESCRIPTION
Related to https://github.com/wavefrontHQ/wavefront-sdk-go/issues/6.
This is an extension of PR #111, which I closed due to having introduced undesired merge commits in git history. 

**Detailed description:**
Make request timeout and TLS properties configurable. 

Add new configuration options to README.

  Signed-off-by: Devon Warshaw <warshawd@vmware.com>
  Signed-off-by: Jeanette Booher <jbooher@vmware.com>
  Signed-off-by: Supraja Narasimhan <suprajan@vmware.com>
