### PR TITLE
add make godoc target so new contributors can easily review godoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+.PHONY: test godoc
+
 test:
 	go test -timeout 10m -v -race ./...
 	go vet ./...
+
+godoc:
+	scripts/godoc-install-hint.sh
+	@echo "\n\nlaunching godoc server. see docs here: http://localhost:6060/pkg/github.com/wavefronthq/wavefront-sdk-go/senders \n\n"
+	godoc -http=:6060

--- a/scripts/godoc-install-hint.sh
+++ b/scripts/godoc-install-hint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+which godoc >/dev/null || (
+  cat <<-'EOF'
+The godoc cli is not installed.
+Install godoc somewhere on your $PATH.
+
+For example, if /usr/local/bin is on your $PATH:
+  GOBIN=/usr/local/bin/ go install golang.org/x/tools/cmd/godoc@latest
+EOF
+)


### PR DESCRIPTION
this PR adds a `make godoc` command.

If godoc is not installed, it will print a hint about installing the godoc cli

If godoc is installed, it will run the godoc http server and print a link to go directly to the wavefront sdk package docs