### PR TITLE
fix: restore support for paths in URLs

### DIFF
--- a/senders/client_factory_test.go
+++ b/senders/client_factory_test.go
@@ -1,4 +1,4 @@
-package senders_test
+package senders
 
 import (
 	"crypto/tls"
@@ -8,68 +8,66 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/wavefronthq/wavefront-sdk-go/senders"
 )
 
 func TestInvalidURL(t *testing.T) {
-	_, err := senders.CreateConfig("%%%%")
+	_, err := createConfig("%%%%")
 	assert.Error(t, err)
 }
 
 func TestScheme(t *testing.T) {
-	_, err := senders.CreateConfig("http://localhost")
+	_, err := createConfig("http://localhost")
 	require.NoError(t, err)
-	_, err = senders.CreateConfig("https://localhost")
+	_, err = createConfig("https://localhost")
 	require.NoError(t, err)
 
-	_, err = senders.CreateConfig("gopher://localhost")
+	_, err = createConfig("gopher://localhost")
 	require.Error(t, err)
 }
 
 func TestDefaultPortsProxy(t *testing.T) {
-	cfg, err := senders.CreateConfig("http://localhost")
+	cfg, err := createConfig("http://localhost")
 	require.NoError(t, err)
 	assert.Equal(t, 2878, cfg.MetricsPort)
 	assert.Equal(t, 30001, cfg.TracesPort)
 }
 
 func TestMetricPrefixProxy(t *testing.T) {
-	cfg, err := senders.CreateConfig("http://localhost")
+	cfg, err := createConfig("http://localhost")
 	require.NoError(t, err)
 	assert.False(t, cfg.Direct())
 	assert.Equal(t, "~sdk.go.core.sender.proxy", cfg.MetricPrefix())
 }
 
 func TestMetricPrefixDirect(t *testing.T) {
-	cfg, err := senders.CreateConfig("http://11111111-2222-3333-4444-555555555555@localhost")
+	cfg, err := createConfig("http://11111111-2222-3333-4444-555555555555@localhost")
 	require.NoError(t, err)
 	assert.True(t, cfg.Direct())
 	assert.Equal(t, "~sdk.go.core.sender.direct", cfg.MetricPrefix())
 }
 func TestDefaultPortsDIHttp(t *testing.T) {
-	cfg, err := senders.CreateConfig("http://11111111-2222-3333-4444-555555555555@localhost")
+	cfg, err := createConfig("http://11111111-2222-3333-4444-555555555555@localhost")
 	require.NoError(t, err)
 	assert.Equal(t, 80, cfg.MetricsPort)
 	assert.Equal(t, 80, cfg.TracesPort)
 }
 
 func TestDefaultPortsDIHttps(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://11111111-2222-3333-4444-555555555555@localhost")
+	cfg, err := createConfig("https://11111111-2222-3333-4444-555555555555@localhost")
 	require.NoError(t, err)
 	assert.Equal(t, 443, cfg.MetricsPort)
 	assert.Equal(t, 443, cfg.TracesPort)
 }
 
 func TestPortExtractedFromURL(t *testing.T) {
-	cfg, err := senders.CreateConfig("http://localhost:1234")
+	cfg, err := createConfig("http://localhost:1234")
 	require.NoError(t, err)
 	assert.Equal(t, 1234, cfg.MetricsPort)
 	assert.Equal(t, 1234, cfg.TracesPort)
 }
 
 func TestUrlWithPortAndPath(t *testing.T) {
-	cfg, err := senders.CreateConfig("http://localhost:8071/wavefront")
+	cfg, err := createConfig("http://localhost:8071/wavefront")
 	require.NoError(t, err)
 	assert.Equal(t, 8071, cfg.MetricsPort)
 	assert.Equal(t, 8071, cfg.TracesPort)
@@ -78,14 +76,14 @@ func TestUrlWithPortAndPath(t *testing.T) {
 }
 
 func TestMetricsURLWithPortAndPath(t *testing.T) {
-	cfg, err := senders.CreateConfig("http://localhost:8071/wavefront")
+	cfg, err := createConfig("http://localhost:8071/wavefront")
 	require.NoError(t, err)
-	assert.Equal(t, "http://localhost:8071/wavefront", cfg.MetricsURL())
-	assert.Equal(t, "http://localhost:8071/wavefront", cfg.TracesURL())
+	assert.Equal(t, "http://localhost:8071/wavefront", cfg.metricsURL())
+	assert.Equal(t, "http://localhost:8071/wavefront", cfg.tracesURL())
 }
 
 func TestToken(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://my-api-token@localhost")
+	cfg, err := createConfig("https://my-api-token@localhost")
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-api-token", cfg.Token)
@@ -93,7 +91,7 @@ func TestToken(t *testing.T) {
 }
 
 func TestDefaults(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost")
+	cfg, err := createConfig("https://localhost")
 	require.NoError(t, err)
 
 	assert.Equal(t, 10000, cfg.BatchSize)
@@ -106,49 +104,49 @@ func TestDefaults(t *testing.T) {
 }
 
 func TestBatchSize(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost", senders.BatchSize(123))
+	cfg, err := createConfig("https://localhost", BatchSize(123))
 	require.NoError(t, err)
 
 	assert.Equal(t, 123, cfg.BatchSize)
 }
 
 func TestFlushIntervalSeconds(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost", senders.FlushIntervalSeconds(123))
+	cfg, err := createConfig("https://localhost", FlushIntervalSeconds(123))
 	require.NoError(t, err)
 
 	assert.Equal(t, 123*time.Second, cfg.FlushInterval)
 }
 
 func TestFlushInterval(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost", senders.FlushInterval(1*time.Hour))
+	cfg, err := createConfig("https://localhost", FlushInterval(1*time.Hour))
 	require.NoError(t, err)
 
 	assert.Equal(t, 1*time.Hour, cfg.FlushInterval)
 }
 
 func TestMaxBufferSize(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost", senders.MaxBufferSize(123))
+	cfg, err := createConfig("https://localhost", MaxBufferSize(123))
 	require.NoError(t, err)
 
 	assert.Equal(t, 123, cfg.MaxBufferSize)
 }
 
 func TestMetricsPort(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost", senders.MetricsPort(123))
+	cfg, err := createConfig("https://localhost", MetricsPort(123))
 	require.NoError(t, err)
 
 	assert.Equal(t, 123, cfg.MetricsPort)
 }
 
 func TestTracesPort(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost", senders.TracesPort(123))
+	cfg, err := createConfig("https://localhost", TracesPort(123))
 	require.NoError(t, err)
 
 	assert.Equal(t, 123, cfg.TracesPort)
 }
 
 func TestSDKMetricsTags(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost", senders.SDKMetricsTags(map[string]string{"foo": "bar"}), senders.SDKMetricsTags(map[string]string{"foo1": "bar1"}))
+	cfg, err := createConfig("https://localhost", SDKMetricsTags(map[string]string{"foo": "bar"}), SDKMetricsTags(map[string]string{"foo1": "bar1"}))
 	require.NoError(t, err)
 
 	assert.Equal(t, "bar", cfg.SDKMetricsTags["foo"])
@@ -156,7 +154,7 @@ func TestSDKMetricsTags(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	cfg, err := senders.CreateConfig("https://localhost", senders.Timeout(60*time.Second))
+	cfg, err := createConfig("https://localhost", Timeout(60*time.Second))
 	require.NoError(t, err)
 
 	assert.Equal(t, 60*time.Second, cfg.Timeout)
@@ -170,7 +168,7 @@ func TestTLSConfigOptions(t *testing.T) {
 	tlsConfig := tls.Config{
 		RootCAs: caCertPool,
 	}
-	cfg, err := senders.CreateConfig("https://localhost", senders.TLSConfigOptions(&tlsConfig))
+	cfg, err := createConfig("https://localhost", TLSConfigOptions(&tlsConfig))
 	require.NoError(t, err)
 	assert.Equal(t, caCertPool, cfg.TLSConfig.RootCAs)
 }
@@ -178,16 +176,16 @@ func TestTLSConfigOptions(t *testing.T) {
 func TestSDKMetricsTags_Immutability(t *testing.T) {
 	map1 := map[string]string{"foo": "bar"}
 	map2 := map[string]string{"baz": "none"}
-	option1 := senders.SDKMetricsTags(map1)
-	option2 := senders.SDKMetricsTags(map2)
+	option1 := SDKMetricsTags(map1)
+	option2 := SDKMetricsTags(map2)
 	map1["foo"] = "wrong"
 	map2["baz"] = "wrong"
-	cfg, err := senders.CreateConfig("https://localhost", option1, option2)
+	cfg, err := createConfig("https://localhost", option1, option2)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", cfg.SDKMetricsTags["foo"])
 	assert.Equal(t, "none", cfg.SDKMetricsTags["baz"])
 
-	cfg2, err := senders.CreateConfig("https://localhost", option1)
+	cfg2, err := createConfig("https://localhost", option1)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", cfg2.SDKMetricsTags["foo"])
 	_, ok := cfg2.SDKMetricsTags["baz"]

--- a/senders/integration_test.go
+++ b/senders/integration_test.go
@@ -16,6 +16,20 @@ func TestEndToEnd(t *testing.T) {
 
 	assert.Equal(t, 1, len(testServer.MetricLines))
 	assert.Equal(t, "\"my-metric\" 20 source=\"localhost\"", testServer.MetricLines[0])
+	assert.Equal(t, "/report?f=wavefront", testServer.LastRequestURL)
+}
+
+func TestEndToEndWithPath(t *testing.T) {
+	testServer := startTestServer()
+	defer testServer.Close()
+	sender, err := NewSender(testServer.URL + "/test-path")
+	require.NoError(t, err)
+	require.NoError(t, sender.SendMetric("my metric", 20, 0, "localhost", nil))
+	require.NoError(t, sender.Flush())
+
+	assert.Equal(t, 1, len(testServer.MetricLines))
+	assert.Equal(t, "\"my-metric\" 20 source=\"localhost\"", testServer.MetricLines[0])
+	assert.Equal(t, "/test-path/report?f=wavefront", testServer.LastRequestURL)
 }
 
 func TestTLSEndToEnd(t *testing.T) {

--- a/senders/test_server_test.go
+++ b/senders/test_server_test.go
@@ -15,7 +15,6 @@ func startTestServer() *testServer {
 	handler.httpServer = server
 	handler.URL = server.URL
 	return handler
-
 }
 
 func startTLSTestServer() *testServer {
@@ -27,9 +26,10 @@ func startTLSTestServer() *testServer {
 }
 
 type testServer struct {
-	MetricLines []string
-	httpServer  *httptest.Server
-	URL         string
+	MetricLines    []string
+	httpServer     *httptest.Server
+	URL            string
+	LastRequestURL string
 }
 
 func (s *testServer) TLSConfig() *tls.Config {
@@ -46,6 +46,7 @@ func (s *testServer) ServeHTTP(writer http.ResponseWriter, request *http.Request
 		writer.WriteHeader(500)
 	}
 	s.MetricLines = append(s.MetricLines, newLines...)
+	s.LastRequestURL = request.URL.String()
 	writer.WriteHeader(200)
 }
 


### PR DESCRIPTION
addresses #133 

This PR restores support for paths in URLs passed to the Wavefront sender.

* adds a top-level integration test for path support, so that it's less likely to break in the future
* makes several helper funcs internal
* moves sender package tests into sender package (so they can call non-public funcs)
