### PR TITLE
chore: update github action to reflect current supported golang versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.16.x, 1.17.x, 1.18.x ]
+        go-version: [ 1.19.x, 1.20.x ]
     name: Go ${{ matrix.go-version }}
     steps:
       - uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wavefronthq/wavefront-sdk-go
 
-go 1.17
+go 1.19
 
 require (
 	github.com/caio/go-tdigest v3.1.0+incompatible


### PR DESCRIPTION
Our github action runs our tests across 3 versions of golang: (`1.16.x`,`1.17.x`, `1.18.x`). These versions are all considered unsupported according to Go's release policy:

https://go.dev/doc/devel/release#policy

This PR updates the matrix to include only the currently supported golang versions: `1.19.x` and `1.20.x`

#138 is currently failing because the new version of `stretchr/testify` uses a reflection API that doesn't exist in `1.16.x`.

Maybe there are good arguments to continue to support `1.18.x` or `1.17.x`, but I think dropping `1.16.x` now is the right call.