### PR TITLE
docs: add an example of sending to a Wavefront proxy with custom ports

### DIFF
--- a/senders/example_newsender_proxy_test.go
+++ b/senders/example_newsender_proxy_test.go
@@ -6,8 +6,14 @@ import (
 
 func ExampleNewSender_proxy() {
 	// For Proxy endpoints, by default metrics and histograms are sent to
-	// port 2878 and spans are sent to port 30001.
+	// port 2878 and traces are sent to port 30001.
 	sender, err := wavefront.NewSender("http://localhost")
+
+	// To use non-default ports, specify the metric/histogram port in the url,
+	// and set the port for traces using the TracesPort Option.
+	sender, err = wavefront.NewSender("https://localhost:4443",
+		wavefront.TracesPort(55555))
+
 	if err != nil {
 		// handle error
 	}


### PR DESCRIPTION
fixes #137