### PR TITLE
chore: fix ineffective assigns, enable ineffassign linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,7 @@ linters:
   - gofmt
   - gci
 #  - revive
-#  - ineffassign
+  - ineffassign
 #  - staticcheck
 issues:
   exclude-rules:

--- a/internal/auth/csp/api_token_client.go
+++ b/internal/auth/csp/api_token_client.go
@@ -1,9 +1,6 @@
 package csp
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -36,16 +33,5 @@ func (c *APITokenClient) GetAccessToken() (*AuthorizeResponse, error) {
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode > 399 {
-		return nil, fmt.Errorf("authentication failed: %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	var cspResponse AuthorizeResponse
-	err = json.Unmarshal(body, &cspResponse)
-
-	if err != nil {
-		return nil, err
-	}
-	return &cspResponse, nil
+	return parseAuthorizeResponse(resp)
 }

--- a/internal/auth/csp/client_credentials.go
+++ b/internal/auth/csp/client_credentials.go
@@ -2,9 +2,6 @@ package csp
 
 import (
 	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -31,7 +28,6 @@ func (c *ClientCredentialsClient) GetAccessToken() (*AuthorizeResponse, error) {
 	}
 	requestBody := values.Encode()
 	req, err := http.NewRequest("POST", c.BaseURL+oauthPath, strings.NewReader(requestBody))
-
 	if err != nil {
 		return nil, err
 	}
@@ -40,23 +36,11 @@ func (c *ClientCredentialsClient) GetAccessToken() (*AuthorizeResponse, error) {
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := client.Do(req)
-
 	if err != nil {
 		return nil, err
 	}
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode > 399 {
-		return nil, fmt.Errorf("authentication failed: %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	var cspResponse AuthorizeResponse
-	err = json.Unmarshal(body, &cspResponse)
-
-	if err != nil {
-		return nil, err
-	}
-	return &cspResponse, nil
+	return parseAuthorizeResponse(resp)
 }

--- a/internal/auth/csp/response.go
+++ b/internal/auth/csp/response.go
@@ -1,0 +1,27 @@
+package csp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func parseAuthorizeResponse(resp *http.Response) (*AuthorizeResponse, error) {
+	if resp.StatusCode > 399 {
+		return nil, fmt.Errorf("authentication failed: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var cspResponse AuthorizeResponse
+	err = json.Unmarshal(body, &cspResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cspResponse, nil
+}

--- a/internal/histogram/formatter_test.go
+++ b/internal/histogram/formatter_test.go
@@ -84,9 +84,9 @@ func TestHistogramLine(t *testing.T) {
 		1533529977, "test_source", map[string]string{"env": "test"}, "")
 	expected = "!M 1533529977 #20 30 \"request.latency\" source=\"test_source\" \"env\"=\"test\"\n" +
 		"!H 1533529977 #20 30 \"request.latency\" source=\"test_source\" \"env\"=\"test\"\n"
-	if len(line) != len(expected) {
-		t.Errorf("lines don't match. expected: %s, actual: %s", expected, line)
-	}
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, line)
 }
 
 func makeCentroids() []histogram.Centroid {

--- a/senders/real_sender_test.go
+++ b/senders/real_sender_test.go
@@ -16,6 +16,7 @@ func TestSendDirect(t *testing.T) {
 	directServer := startTestServer(false)
 	defer directServer.Close()
 	updatedUrl, err := url.Parse(directServer.URL)
+	assert.NoError(t, err)
 	updatedUrl.User = url.User(token)
 	wf, err := NewSender(updatedUrl.String())
 
@@ -36,6 +37,7 @@ func TestSendDirectWithTags(t *testing.T) {
 	defer directServer.Close()
 
 	updatedUrl, err := url.Parse(directServer.URL)
+	assert.NoError(t, err)
 	updatedUrl.User = url.User(token)
 	tags := map[string]string{"foo": "bar"}
 	wf, err := NewSender(updatedUrl.String(), SDKMetricsTags(tags))


### PR DESCRIPTION
this PR enables the `ineffassign` linter, and fixes existing ineffective assigns (mostly ignored errors)

It also extracts a common http response parsing helper method to remove some duplication (which also previously included an ineffective assign)