### PR TITLE
refactor: simplify Reporter interface

### DIFF
--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -7,7 +7,6 @@ import "net/http"
 // Reporter is an interface for reporting data to a Wavefront service.
 type Reporter interface {
 	Report(format string, pointLines string) (*http.Response, error)
-	ReportEvent(event string) (*http.Response, error)
 }
 
 type Flusher interface {

--- a/internal/lines.go
+++ b/internal/lines.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -180,14 +179,7 @@ func (lh *RealLineHandler) FlushAll() error {
 
 func (lh *RealLineHandler) report(lines []string) error {
 	strLines := strings.Join(lines, "")
-	var resp *http.Response
-	var err error
-
-	if lh.Format == eventFormat {
-		resp, err = lh.Reporter.ReportEvent(strLines)
-	} else {
-		resp, err = lh.Reporter.Report(lh.Format, strLines)
-	}
+	resp, err := lh.Reporter.Report(lh.Format, strLines)
 
 	if err != nil {
 		if shouldRetry(err) {

--- a/senders/live_test.go
+++ b/senders/live_test.go
@@ -3,6 +3,7 @@ package senders
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -54,6 +55,33 @@ func TestWF_API_TOKEN_LIVE(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, sender.SendMetric("test.go-metrics.can-send", 1, 0, "go test",
 		map[string]string{"scenario": "direct-wf-token"}))
+	assert.NoError(t, sender.Flush())
+	sender.Close()
+}
+
+func TestEventDirectSend_LIVE(t *testing.T) {
+	skipUnlessVarsAreSet(t)
+
+	sender, err := NewSender(
+		os.Getenv("LIVE_TEST_HOST"),
+		APIToken(os.Getenv("LIVE_TEST_WF_API_TOKEN")),
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, sender.SendEvent("test.an-event", time.Now().Add(-30*time.Minute).UnixMilli(), time.Now().Add(5*time.Minute).UnixMilli(), "go test",
+		map[string]string{"scenario": "send-event-direct"}))
+	assert.NoError(t, sender.Flush())
+	sender.Close()
+}
+
+func TestEventProxySend_LIVE(t *testing.T) {
+	skipUnlessVarsAreSet(t)
+
+	sender, err := NewSender(
+		os.Getenv("LIVE_TEST_PROXY_HOST"),
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, sender.SendEvent("test.an-event", time.Now().Add(-30*time.Minute).UnixMilli(), time.Now().Add(5*time.Minute).UnixMilli(), "go test",
+		map[string]string{"scenario": "send-event-proxy"}))
 	assert.NoError(t, sender.Flush())
 	sender.Close()
 }


### PR DESCRIPTION
This refactor simplifies the `Reporter` interface by pushing a conditional from the caller into the `Report` method and eliminating `ReportEvent` from the interface.

* simplifies code at the call site
* makes the interface smaller
* applies [Tell, Don't Ask](https://martinfowler.com/bliki/TellDontAsk.html)