### PR TITLE
chore: update pipelines, workflows, and documents to reflect switch to main as default branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   run_suite:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 ## How to Release the SDK
 
-1. Make sure that all changes for the release are merged with the master branch.
-2. From the root directory of the project in the master branch, run the following commands.
+1. Make sure that all changes for the release are merged with the `main` branch.
+2. From the root directory of the project in the `main` branch, run the following commands.
     1. `go install ./...`
     2. `go test ./...`
     3. `go vet ./...`

--- a/ci/pipelines/osspi-wavefront-sdk-go/pipeline.yml
+++ b/ci/pipelines/osspi-wavefront-sdk-go/pipeline.yml
@@ -11,7 +11,7 @@ resources:
   type: git
   source:
     uri: git@github.com:wavefrontHQ/wavefront-sdk-go
-    branch: master
+    branch: main
     private_key: ((tas2to-osspi.github-private-key))
 
 jobs:


### PR DESCRIPTION
We recently switched our default branch from `master` to `main`. This PR changes our CI and documentation to reflect the new default branch.