### PR TITLE
feat: add an option to set the http.Client for the Sender

### DIFF
--- a/internal/reporter.go
+++ b/internal/reporter.go
@@ -3,11 +3,9 @@ package internal
 import (
 	"bytes"
 	"compress/gzip"
-	"crypto/tls"
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/wavefronthq/wavefront-sdk-go/internal/auth"
 )
@@ -26,14 +24,6 @@ func NewReporter(server string, tokenService auth.Service, client *http.Client) 
 		tokenService: tokenService,
 		client:       client,
 	}
-}
-
-func NewClient(timeout time.Duration, tlsConfig *tls.Config) *http.Client {
-	if tlsConfig == nil {
-		return &http.Client{Timeout: timeout}
-	}
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
-	return &http.Client{Timeout: timeout, Transport: transport}
 }
 
 // Report creates and sends a POST to the reportEndpoint with the given pointLines

--- a/internal/reporter_test.go
+++ b/internal/reporter_test.go
@@ -1,11 +1,8 @@
 package internal
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,28 +14,4 @@ func TestReporter_BuildRequest(t *testing.T) {
 	request, err := r.buildRequest("wavefront", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:8010/wavefront/report?f=wavefront", request.URL.String())
-}
-
-func TestNewClient_WithNilTLSConfig(t *testing.T) {
-	client := NewClient(10*time.Second, nil)
-	assert.Equal(t, nil, client.Transport)
-}
-
-func TestNewClient_WithCustomTLSConfig(t *testing.T) {
-	caCertPool := x509.NewCertPool()
-	fakeCert := []byte("Not a real cert")
-	caCertPool.AppendCertsFromPEM(fakeCert)
-
-	tlsConfig := &tls.Config{
-		RootCAs: caCertPool,
-	}
-
-	emptyTLSConfig := &tls.Config{}
-
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
-	transportWithEmptyTLSConfig := &http.Transport{TLSClientConfig: emptyTLSConfig}
-
-	client := NewClient(10*time.Second, tlsConfig)
-	assert.Equal(t, transport, client.Transport)
-	assert.NotEqual(t, transportWithEmptyTLSConfig, client.Transport)
 }

--- a/senders/configuration.go
+++ b/senders/configuration.go
@@ -1,9 +1,9 @@
 package senders
 
 import (
-	"crypto/tls"
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -47,15 +47,12 @@ type configuration struct {
 
 	// interval (in seconds) at which to flush data to Wavefront. defaults to 1 Second.
 	// together with batch size controls the max theoretical throughput of the sender.
-	FlushInterval  time.Duration
-	SDKMetricsTags map[string]string
-	Path           string
-
-	Timeout time.Duration
-
-	TLSConfig *tls.Config
-
-	Authentication interface{}
+	FlushInterval           time.Duration
+	SDKMetricsTags          map[string]string
+	Path                    string
+	Authentication          interface{}
+	httpClientConfiguration *httpClientConfiguration
+	HTTPClient              *http.Client
 }
 
 func (c *configuration) Direct() bool {
@@ -64,14 +61,14 @@ func (c *configuration) Direct() bool {
 
 func createConfig(wfURL string, setters ...Option) (*configuration, error) {
 	cfg := &configuration{
-		MetricsPort:         defaultMetricsPort,
-		TracesPort:          defaultTracesPort,
-		BatchSize:           defaultBatchSize,
-		MaxBufferSize:       defaultBufferSize,
-		FlushInterval:       defaultFlushInterval,
-		SendInternalMetrics: true,
-		SDKMetricsTags:      map[string]string{},
-		Timeout:             defaultTimeout,
+		MetricsPort:             defaultMetricsPort,
+		TracesPort:              defaultTracesPort,
+		BatchSize:               defaultBatchSize,
+		MaxBufferSize:           defaultBufferSize,
+		FlushInterval:           defaultFlushInterval,
+		SendInternalMetrics:     true,
+		SDKMetricsTags:          map[string]string{},
+		httpClientConfiguration: &httpClientConfiguration{Timeout: defaultTimeout},
 	}
 
 	u, err := url.Parse(wfURL)
@@ -119,6 +116,16 @@ func createConfig(wfURL string, setters ...Option) (*configuration, error) {
 		u.Host = u.Hostname()
 	}
 	cfg.Server = u.String()
+
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{
+			Timeout: cfg.httpClientConfiguration.Timeout,
+			Transport: &http.Transport{
+				TLSClientConfig: cfg.httpClientConfiguration.TLSClientConfig,
+			},
+		}
+	}
+
 	return cfg, nil
 }
 

--- a/senders/example_newsender_options_test.go
+++ b/senders/example_newsender_options_test.go
@@ -2,6 +2,7 @@ package senders_test
 
 import (
 	"crypto/tls"
+	"net/http"
 	"time"
 
 	wavefront "github.com/wavefronthq/wavefront-sdk-go/senders"
@@ -18,6 +19,13 @@ func ExampleNewSender_options() {
 		wavefront.Timeout(15),                     // Set an HTTP timeout in seconds (default is 10s)
 		wavefront.SendInternalMetrics(false),      // Don't send internal ~sdk.go.* metrics
 		wavefront.TLSConfigOptions(&tls.Config{}), // Set TLS config options.
+		wavefront.HTTPClient(&http.Client{
+			Timeout: 15 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{},
+				IdleConnTimeout: 4 * time.Second,
+			},
+		}), // Provide a fully configured http.Client
 	)
 
 	if err != nil {

--- a/senders/integration_test.go
+++ b/senders/integration_test.go
@@ -2,6 +2,7 @@ package senders
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,7 @@ func TestTLSEndToEnd(t *testing.T) {
 	testServer.httpServer.Client()
 	tlsConfig := testServer.TLSConfig()
 
-	sender, err := NewSender(testServer.URL, TLSConfigOptions(tlsConfig))
+	sender, err := NewSender(testServer.URL, TLSConfigOptions(tlsConfig), Timeout(10*time.Second))
 	require.NoError(t, err)
 	require.NoError(t, sender.SendMetric("my metric", 20, 0, "localhost", nil))
 	require.NoError(t, sender.Flush())

--- a/senders/new_sender.go
+++ b/senders/new_sender.go
@@ -15,7 +15,7 @@ func NewSender(wfURL string, setters ...Option) (Sender, error) {
 	}
 
 	tokenService := tokenServiceForCfg(cfg)
-	client := internal.NewClient(cfg.Timeout, cfg.TLSConfig)
+	client := cfg.HTTPClient
 	metricsReporter := internal.NewReporter(cfg.metricsURL(), tokenService, client)
 	tracesReporter := internal.NewReporter(cfg.tracesURL(), tokenService, client)
 


### PR DESCRIPTION
related to https://github.com/influxdata/telegraf/issues/14090

This PR introduces a new `Option`, `HTTPClient`, allowing users to override the `*http.Client` used by the `Sender`.

This allows a variety of customization options, such as proxy settings, idle connection management, and TLS Options. It is intended to integrate well with Telegraf's http config, which can generate an `http.Client` from a standard `toml` configuration (https://github.com/influxdata/telegraf/blob/master/plugins/common/http/config.go)

This PR ~~reimplements the existing `Timeout` and `TLSConfig` options in terms of `configuration.HTTPClient`, and~~ eliminates the internal `NewClient` factory.

~~feedback request: the PR logs a warning if you try to use more than one of `Timeout`, `TLSConfig`, and `HTTPClient` for the same `Sender`, because subsequent calls will clobber the first call. Curious if anyone thinks this should work differently.~~

I had a change of heart about my initial solution to mixing `Timeout`, `TLSConfig`, and `HTTPClient`. I just pushed a second commit with a different solution. This allows `Timeout` and `TLSConfig` to be used together, but prints a warning if either are used after `HTTPClient`. The intended logic now is that if you set an HTTPClient, the `Sender` will just use that, but you can alternatively provide either, both, or neither of `Timeout` and `TLSConfigOptions` as easier shorthand methods for changing those two settings. In that case, we'll make an `http.Client` for you.