### PR TITLE
chore: Sender refactor

### DIFF
--- a/internal/handler_factory.go
+++ b/internal/handler_factory.go
@@ -1,0 +1,96 @@
+package internal
+
+import (
+	"time"
+
+	"github.com/wavefronthq/wavefront-sdk-go/internal/sdkmetrics"
+)
+
+type HandlerFactory struct {
+	metricsReporter    Reporter
+	tracesReporter     Reporter
+	flushInterval      time.Duration
+	bufferSize         int
+	lineHandlerOptions []LineHandlerOption
+}
+
+func NewHandlerFactory(
+	metricsReporter,
+	tracesReporter Reporter,
+	flushInterval time.Duration,
+	bufferSize int,
+	registry sdkmetrics.Registry) *HandlerFactory {
+	return &HandlerFactory{
+		metricsReporter: metricsReporter,
+		tracesReporter:  tracesReporter,
+		flushInterval:   flushInterval,
+		bufferSize:      bufferSize,
+		lineHandlerOptions: []LineHandlerOption{
+			SetRegistry(registry),
+		},
+	}
+}
+
+func (f *HandlerFactory) NewPointHandler(batchSize int) *RealLineHandler {
+	return NewLineHandler(
+		f.metricsReporter,
+		metricFormat,
+		f.flushInterval,
+		batchSize,
+		f.bufferSize,
+		append(f.lineHandlerOptions,
+			SetHandlerPrefix("points"))...,
+	)
+}
+
+func (f *HandlerFactory) NewHistogramHandler(batchSize int) *RealLineHandler {
+	return NewLineHandler(
+		f.metricsReporter,
+		histogramFormat,
+		f.flushInterval,
+		batchSize,
+		f.bufferSize,
+		append(f.lineHandlerOptions,
+			SetHandlerPrefix("histograms"))...,
+	)
+}
+
+func (f *HandlerFactory) NewSpanHandler(batchSize int) *RealLineHandler {
+	return NewLineHandler(
+		f.tracesReporter,
+		traceFormat,
+		f.flushInterval,
+		batchSize,
+		f.bufferSize,
+		append(f.lineHandlerOptions,
+			SetHandlerPrefix("spans"))...,
+	)
+}
+
+func (f *HandlerFactory) NewSpanLogHandler(batchSize int) *RealLineHandler {
+	return NewLineHandler(
+		f.tracesReporter,
+		spanLogsFormat,
+		f.flushInterval,
+		batchSize,
+		f.bufferSize,
+		append(f.lineHandlerOptions,
+			SetHandlerPrefix("span_logs"))...,
+	)
+}
+
+// NewEventHandler creates a RealLineHandler for the Event type
+// The Event handler always sets "SetLockOnThrottledError" to true
+// And always uses a batch size of exactly 1.
+func (f *HandlerFactory) NewEventHandler() *RealLineHandler {
+	return NewLineHandler(
+		f.metricsReporter,
+		eventFormat,
+		f.flushInterval,
+		1,
+		f.bufferSize,
+		append(f.lineHandlerOptions,
+			SetHandlerPrefix("events"),
+			SetLockOnThrottledError(true))...,
+	)
+}

--- a/internal/lines.go
+++ b/internal/lines.go
@@ -15,11 +15,11 @@ import (
 )
 
 const (
-	MetricFormat    = "wavefront"
-	HistogramFormat = "histogram"
-	TraceFormat     = "trace"
-	SpanLogsFormat  = "spanLogs"
-	EventFormat     = "event"
+	metricFormat    = "wavefront"
+	histogramFormat = "histogram"
+	traceFormat     = "trace"
+	spanLogsFormat  = "spanLogs"
+	eventFormat     = "event"
 )
 
 type RealLineHandler struct {
@@ -183,7 +183,7 @@ func (lh *RealLineHandler) report(lines []string) error {
 	var resp *http.Response
 	var err error
 
-	if lh.Format == EventFormat {
+	if lh.Format == eventFormat {
 		resp, err = lh.Reporter.ReportEvent(strLines)
 	} else {
 		resp, err = lh.Reporter.Report(lh.Format, strLines)

--- a/senders/option.go
+++ b/senders/option.go
@@ -175,3 +175,11 @@ func SDKMetricsTags(tags map[string]string) Option {
 		}
 	}
 }
+
+func copyTags(orig map[string]string) map[string]string {
+	result := make(map[string]string, len(orig))
+	for key, value := range orig {
+		result[key] = value
+	}
+	return result
+}

--- a/senders/real_sender.go
+++ b/senders/real_sender.go
@@ -38,17 +38,6 @@ type realSender struct {
 	proxy            bool
 }
 
-func newLineHandler(reporter internal.Reporter, cfg *configuration, format, prefix string, registry sdkmetrics.Registry) *internal.RealLineHandler {
-	opts := []internal.LineHandlerOption{internal.SetHandlerPrefix(prefix), internal.SetRegistry(registry)}
-	batchSize := cfg.BatchSize
-	if format == internal.EventFormat {
-		batchSize = 1
-		opts = append(opts, internal.SetLockOnThrottledError(true))
-	}
-
-	return internal.NewLineHandler(reporter, format, cfg.FlushInterval, batchSize, cfg.MaxBufferSize, opts...)
-}
-
 func (sender *realSender) Start() {
 	sender.pointHandler.Start()
 	sender.histoHandler.Start()

--- a/senders/real_sender.go
+++ b/senders/real_sender.go
@@ -28,7 +28,6 @@ type Sender interface {
 }
 
 type realSender struct {
-	reporter         internal.Reporter
 	defaultSource    string
 	pointHandler     internal.LineHandler
 	histoHandler     internal.LineHandler

--- a/senders/wavefront_sender_test.go
+++ b/senders/wavefront_sender_test.go
@@ -17,7 +17,6 @@ func TestWavefrontSender_SendMetric(t *testing.T) {
 	spanLogHandler := &mockHandler{}
 	eventHandler := &mockHandler{}
 	sender := realSender{
-		reporter:         nil,
 		defaultSource:    "test",
 		pointHandler:     pointHandler,
 		histoHandler:     histoHandler,
@@ -52,7 +51,6 @@ func TestWavefrontSender_SendDeltaCounter(t *testing.T) {
 	spanLogHandler := &mockHandler{}
 	eventHandler := &mockHandler{}
 	sender := realSender{
-		reporter:         nil,
 		defaultSource:    "test",
 		pointHandler:     pointHandler,
 		histoHandler:     histoHandler,
@@ -92,7 +90,6 @@ func TestWavefrontSender_SendDistribution(t *testing.T) {
 	spanLogHandler := &mockHandler{}
 	eventHandler := &mockHandler{}
 	sender := realSender{
-		reporter:         nil,
 		defaultSource:    "test",
 		pointHandler:     pointHandler,
 		histoHandler:     histoHandler,
@@ -137,7 +134,6 @@ func TestWavefrontSender_SendSpan(t *testing.T) {
 	spanLogHandler := &mockHandler{}
 	eventHandler := &mockHandler{}
 	sender := realSender{
-		reporter:         nil,
 		defaultSource:    "test",
 		pointHandler:     pointHandler,
 		histoHandler:     histoHandler,
@@ -204,7 +200,6 @@ func TestWavefrontSender_SendSpan_SpanLogs(t *testing.T) {
 	spanLogHandler := &mockHandler{}
 	eventHandler := &mockHandler{}
 	sender := realSender{
-		reporter:         nil,
 		defaultSource:    "test",
 		pointHandler:     pointHandler,
 		histoHandler:     histoHandler,
@@ -270,7 +265,6 @@ func TestWavefrontSender_SendEventWithProxyFalse(t *testing.T) {
 	spanLogHandler := &mockHandler{}
 	eventHandler := &mockHandler{}
 	sender := realSender{
-		reporter:         nil,
 		defaultSource:    "test",
 		pointHandler:     pointHandler,
 		histoHandler:     histoHandler,
@@ -301,7 +295,6 @@ func TestWavefrontSender_SendEventWithProxyTrue(t *testing.T) {
 	spanLogHandler := &mockHandler{}
 	eventHandler := &mockHandler{}
 	sender := realSender{
-		reporter:         nil,
 		defaultSource:    "test",
 		pointHandler:     pointHandler,
 		histoHandler:     histoHandler,


### PR DESCRIPTION
The `NewSender` function currently uses a pattern like this:

```
sender.pointHandler = newLineHandler(metricsReporter, cfg, internal.MetricFormat, "points", sender.internalRegistry)
	sender.histoHandler = newLineHandler(metricsReporter, cfg, internal.HistogramFormat, "histograms", sender.internalRegistry)
	sender.spanHandler = newLineHandler(tracesReporter, cfg, internal.TraceFormat, "spans", sender.internalRegistry)
	sender.spanLogHandler = newLineHandler(tracesReporter, cfg, internal.SpanLogsFormat, "span_logs", sender.internalRegistry)
```

In this pattern, the caller must know that you send `points` with the `metricsReporter`, you use the `points` prefix, and you set the `MetricFormat`.

This PR moves this knowledge into dedicated factory functions for each line type, so that the factory knows the information, and the caller only needs to identify the right kind of handler to create - the factory is responsible for knowing how to create valid handlers.

## idea: keep pushing type-specific logic into the `Handler` abstraction

right now the `Sender` has methods that call a particular formatter and then pass its output to the correct handler. For example, `SendMetric` calls `metric.Line` and then tries to send that with the `sender.pointHandler`. It seems as though we could maybe package the line formatter and the line handler together somehow - why have the `Sender` know about so many `handlers` and have to know which one to use which format with, when we could instead have the handler itself know the format transformation it needs to do, in the same way that it knows what prefixes and headers to put on its HTTP requests?

## idea: the `Handler` is actually a `FormatSpecificBatchSender` or something like that.

The `Handler` name seems to hide the fact that this abstraction is where formatted lines get batched together and eventually sent out.