### PR TITLE
refactor: type-specific 'handlers'

### DIFF
--- a/internal/background_flusher.go
+++ b/internal/background_flusher.go
@@ -13,11 +13,11 @@ type BackgroundFlusher interface {
 type backgroundFlusher struct {
 	ticker   *time.Ticker
 	interval time.Duration
-	handler  LineHandler
+	handler  BatchBuilder
 	stop     chan struct{}
 }
 
-func NewBackgroundFlusher(interval time.Duration, handler LineHandler) BackgroundFlusher {
+func NewBackgroundFlusher(interval time.Duration, handler BatchBuilder) BackgroundFlusher {
 	return &backgroundFlusher{
 		interval: interval,
 		handler:  handler,

--- a/internal/delta/formatter.go
+++ b/internal/delta/formatter.go
@@ -1,0 +1,18 @@
+package delta
+
+import (
+	"fmt"
+
+	"github.com/wavefronthq/wavefront-sdk-go/internal"
+	"github.com/wavefronthq/wavefront-sdk-go/internal/metric"
+)
+
+func Line(name string, value float64, source string, tags map[string]string, defaultSource string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("empty metric name")
+	}
+	if !internal.HasDeltaPrefix(name) {
+		name = internal.DeltaCounterName(name)
+	}
+	return metric.Line(name, value, 0, source, tags, defaultSource)
+}

--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -24,7 +24,7 @@ type ConnectionHandler interface {
 	Flusher
 }
 
-type LineHandler interface {
+type BatchBuilder interface {
 	HandleLine(line string) error
 	Start()
 	Stop()

--- a/internal/real_batch_builder_test.go
+++ b/internal/real_batch_builder_test.go
@@ -94,7 +94,7 @@ func TestHandleLine_OnAuthError_DoNotBuffer(t *testing.T) {
 }
 
 func TestFlushWithThrottling_WhenThrottling_DelayUntilThrottleInterval(t *testing.T) {
-	lh := &RealLineHandler{
+	lh := &RealBatchBuilder{
 		Reporter:               &fakeReporter{},
 		MaxBufferSize:          100,
 		BatchSize:              10,
@@ -117,7 +117,7 @@ func TestFlushWithThrottling_WhenThrottling_DelayUntilThrottleInterval(t *testin
 }
 
 func TestBackgroundFlushWithThrottling_WhenThrottling_DelayUntilThrottleInterval(t *testing.T) {
-	lh := &RealLineHandler{
+	lh := &RealBatchBuilder{
 		Reporter:               &fakeReporter{},
 		MaxBufferSize:          100,
 		BatchSize:              10,
@@ -142,7 +142,7 @@ func TestBackgroundFlushWithThrottling_WhenThrottling_DelayUntilThrottleInterval
 func TestFlushTicker_WhenThrottlingEnabled_AndReceives406Error_ThrottlesRequestsUntilNextSleepDuration(t *testing.T) {
 	throttledSleepDuration := 250 * time.Millisecond
 	briskTickTime := 50 * time.Millisecond
-	lh := &RealLineHandler{
+	lh := &RealBatchBuilder{
 		Reporter:               &fakeReporter{},
 		MaxBufferSize:          100,
 		BatchSize:              10,
@@ -194,7 +194,7 @@ func checkLength(buffer chan string, length int, msg string, t *testing.T) {
 	}
 }
 
-func addLines(lh *RealLineHandler, linesToAdd int, expectedLen int, t *testing.T) {
+func addLines(lh *RealBatchBuilder, linesToAdd int, expectedLen int, t *testing.T) {
 	for i := 0; i < linesToAdd; i++ {
 		err := lh.HandleLine("dummyLine")
 		if err != nil {
@@ -214,8 +214,8 @@ func makeBuffer(num int) []string {
 	return buf
 }
 
-func makeLineHandler(bufSize, batchSize int) *RealLineHandler {
-	return &RealLineHandler{
+func makeLineHandler(bufSize, batchSize int) *RealBatchBuilder {
+	return &RealBatchBuilder{
 		Reporter:      &fakeReporter{},
 		MaxBufferSize: bufSize,
 		BatchSize:     batchSize,

--- a/internal/reporter_test.go
+++ b/internal/reporter_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestReporter_BuildRequest(t *testing.T) {
-	r := NewReporter("http://localhost:8010/wavefront", auth.NewNoopTokenService(), &http.Client{}).(*reporter)
+	r := NewReporter("http://localhost:8010/wavefront", auth.NewNoopTokenService(), &http.Client{}).(*batchingHTTPReporter)
 	request, err := r.buildRequest("wavefront", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:8010/wavefront/report?f=wavefront", request.URL.String())

--- a/internal/typed_sender.go
+++ b/internal/typed_sender.go
@@ -1,0 +1,53 @@
+package internal
+
+import "github.com/wavefronthq/wavefront-sdk-go/internal/sdkmetrics"
+
+type TypedSender interface {
+	TrySend(string, error) error
+	Start()
+	Stop()
+	Flush() error
+	GetFailureCount() int64
+}
+
+type typedSender struct {
+	tracker     sdkmetrics.SuccessTracker
+	lineHandler BatchBuilder
+}
+
+func (ts *typedSender) Start() {
+	ts.lineHandler.Start()
+}
+
+func (ts *typedSender) Stop() {
+	ts.lineHandler.Stop()
+}
+
+func (ts *typedSender) Flush() error {
+	return ts.lineHandler.Flush()
+}
+
+func (ts *typedSender) GetFailureCount() int64 {
+	return ts.lineHandler.GetFailureCount()
+}
+
+func (ts *typedSender) TrySend(line string, err error) error {
+	if err != nil {
+		ts.tracker.IncInvalid()
+		return err
+	}
+
+	ts.tracker.IncValid()
+	err = ts.lineHandler.HandleLine(line)
+	if err != nil {
+		ts.tracker.IncDropped()
+	}
+	return err
+}
+
+func NewTypedSender(tracker sdkmetrics.SuccessTracker, handler BatchBuilder) TypedSender {
+	return &typedSender{
+		tracker:     tracker,
+		lineHandler: handler,
+	}
+}

--- a/senders/new_sender.go
+++ b/senders/new_sender.go
@@ -29,7 +29,7 @@ func NewSender(wfURL string, setters ...Option) (Sender, error) {
 		sender.internalRegistry = sdkmetrics.NewNoOpRegistry()
 	}
 
-	hf := internal.NewHandlerFactory(
+	hf := internal.NewSenderFactory(
 		metricsReporter,
 		tracesReporter,
 		cfg.FlushInterval,
@@ -37,11 +37,11 @@ func NewSender(wfURL string, setters ...Option) (Sender, error) {
 		sender.internalRegistry,
 	)
 
-	sender.pointHandler = hf.NewPointHandler(cfg.BatchSize)
-	sender.histoHandler = hf.NewHistogramHandler(cfg.BatchSize)
-	sender.spanHandler = hf.NewSpanHandler(cfg.BatchSize)
-	sender.spanLogHandler = hf.NewSpanLogHandler(cfg.BatchSize)
-	sender.eventHandler = hf.NewEventHandler()
+	sender.pointSender = hf.NewPointSender(cfg.BatchSize)
+	sender.histoSender = hf.NewHistogramSender(cfg.BatchSize)
+	sender.spanSender = hf.NewSpanSender(cfg.BatchSize)
+	sender.spanLogSender = hf.NewSpanLogSender(cfg.BatchSize)
+	sender.eventSender = hf.NewEventsSender()
 	sender.Start()
 	return sender, nil
 }


### PR DESCRIPTION
This PR consolidates a repetitive `trySendWith` pattern in `senders.realSender` into a simpler pattern.

This PR assumes that #175 will be merged first

# Old Pattern

```go
func (sender *realSender) SendMetric(name string, value float64, ts int64, source string, tags map[string]string) error {
	line, err := metric.Line(name, value, ts, source, tags, sender.defaultSource)
	return trySendWith(
		line,
		err,
		sender.pointHandler,
		sender.internalRegistry.PointsTracker(),
	)
}
```

# New Pattern
```go
func (sender *realSender) SendMetric(name string, value float64, ts int64, source string, tags map[string]string) error {
	return sender.pointSender.TrySend(metric.Line(name, value, ts, source, tags, sender.defaultSource))
}
```

In the new pattern, the caller of `trySendWith` only needs to tie together two related things (`metric.Line` and `pointSender`), whereas before they needed to chose correctly 3 times (`metric.Line`, `pointHandler`, `PointsTracker`).

The new pattern also mostly allows us to avoid `line, err` as local variables, so that the `Send*` methods can be as short as 1 line.

# Other opportunistic changes

* rename 'LineHandler' interface to 'BatchBuilder' - the main responsibility of this type seems to be collecting lines for a particular point type into batches of the right size and periodically flushing them. Maybe it should actually be called 'BatchBuffer'?
* moves some line-building logic from `SendDelta` into a new `delta.Line` func
* renames `reporter` to `batchingHTTPReporter` (or maybe it should be `HTTPBatchReporter`)

# Issues
- [ ] need to backfill tests for `delta.Line`
- [ ] `wavefront_sender_test.go` has gotten a little weird - it mocks a 2nd-degree dependency instead of a direct one.
- [ ] finalize or revert renames of `LineHandler` and `reporter`
- [ ] maybe `TypedSender` is not a great name